### PR TITLE
Issue #209: Configurable Behavior of FF, REW, NEXT & PREV

### DIFF
--- a/serenity-app/res/values/strings.xml
+++ b/serenity-app/res/values/strings.xml
@@ -184,4 +184,40 @@
     <string name="playing_episode_toast">Playing %1$s %2$s: %3$s</string>
     <string name="no_unwatched_episode_toast">No unwatched episodes found</string>
 
+    <string name="Controls">Controls</string>
+    <string name="skip_forward_time_title">FF Skip Time</string>
+    <string name="skip_forward_time_summary">Time to skip forward when FF button is pressed</string>
+    <string name="skip_backward_time_title">REW Skip Time</string>
+    <string name="skip_backward_time_summary">Time to skip backward when REW button is pressed</string>
+    <string name="next_prev_behavior_title">Next/Prev button behavior</string>
+    <string name="next_prev_behavior_summary"><![CDATA[What should the Next & Prev buttons do]]></string>
+
+    <string-array name="skipListNames">
+        <item>10 Seconds</item>
+        <item>30 Seconds</item>
+        <item>1 Minute</item>
+        <item>3 Minutes</item>
+    </string-array>
+    <string-array name="skipListValues">
+        <item>10000</item>
+        <item>30000</item>
+        <item>60000</item>
+        <item>180000</item>
+    </string-array>
+
+    <string-array name="nextPrevNames">
+        <item>Next item in queue</item>
+        <item>Skip 5%</item>
+        <item>Skip 10%</item>
+        <item>Skip 5 minutes</item>
+        <item>Skip 10 minutes</item>
+    </string-array>
+    <string-array name="nextPrevValues">
+        <item>queue</item>
+        <item>5%</item>
+        <item>10%</item>
+        <item>3000000</item>
+        <item>6000000</item>
+    </string-array>
+
 </resources>

--- a/serenity-app/res/xml/preferences.xml
+++ b/serenity-app/res/xml/preferences.xml
@@ -128,6 +128,30 @@
             android:title="@string/preferred_external_player" />
         
     </PreferenceCategory>
+    <PreferenceCategory android:title="@string/Controls">
+        <ListPreference
+            android:key="skip_forward_time"
+            android:title="@string/skip_forward_time_title"
+            android:summary="@string/skip_forward_time_summary"
+            android:entries="@array/skipListNames"
+            android:entryValues="@array/skipListValues"
+            android:defaultValue="30000"/>
+        <ListPreference
+            android:key="skip_backward_time"
+            android:title="@string/skip_backward_time_title"
+            android:summary="@string/skip_backward_time_summary"
+            android:entries="@array/skipListNames"
+            android:entryValues="@array/skipListValues"
+            android:defaultValue="10000"/>
+        <ListPreference
+            android:key="next_prev_behavior"
+            android:title="@string/next_prev_behavior_title"
+            android:summary="@string/next_prev_behavior_summary"
+            android:entries="@array/nextPrevNames"
+            android:entryValues="@array/nextPrevValues"
+            android:defaultValue="queue"/>
+
+    </PreferenceCategory>
     <PreferenceCategory android:title="@string/preference_remote_control" >
         <CheckBoxPreference
             android:defaultValue="true"

--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/video/player/SerenitySurfaceViewVideoActivity.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/video/player/SerenitySurfaceViewVideoActivity.java
@@ -8,10 +8,10 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included
  * in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
@@ -74,9 +74,9 @@ import android.widget.Toast;
 /**
  * A view that handles the internal video playback and representation of a movie
  * or tv show.
- * 
+ *
  * @author dcarver
- * 
+ *
  */
 public class SerenitySurfaceViewVideoActivity extends SerenityActivity
 		implements SurfaceHolder.Callback {
@@ -226,10 +226,10 @@ public class SerenitySurfaceViewVideoActivity extends SerenityActivity
 		mediaPlayer.setOnErrorListener(new SerenityOnErrorListener());
 		surfaceView = (SurfaceView) findViewById(R.id.surfaceView);
 		videoActivityView = findViewById(R.id.video_playeback);
-        timeOfDayView = findViewById(R.id.time_of_day);
+		timeOfDayView = findViewById(R.id.time_of_day);
 
-        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        if (prefs.getBoolean("overscan_compensation", false)) {
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+		if (prefs.getBoolean("overscan_compensation", false)) {
 			FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) videoActivityView
 					.getLayoutParams();
 			params.setMargins(35, 20, 20, 20);
@@ -240,8 +240,8 @@ public class SerenitySurfaceViewVideoActivity extends SerenityActivity
 		holder.addCallback(this);
 		holder.setSizeFromLayout();
 
-        final boolean showTimeOfDay = prefs.getBoolean("showTimeOfDay", false);
-        timeOfDayView.setVisibility(showTimeOfDay ? View.VISIBLE : View.GONE);
+		final boolean showTimeOfDay = prefs.getBoolean("showTimeOfDay", false);
+		timeOfDayView.setVisibility(showTimeOfDay ? View.VISIBLE : View.GONE);
 
 		retrieveIntentExtras();
 	}
@@ -373,42 +373,18 @@ public class SerenitySurfaceViewVideoActivity extends SerenityActivity
 
 	@Override
 	public boolean onKeyDown(int keyCode, KeyEvent event) {
-		if (mediaController.isShowing()) {
-			if (isKeyCodeBack(keyCode)) {
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+		final int currentPosition = mediaPlayer.getCurrentPosition();
+		final int duration = mediaPlayer.getDuration();
+
+		if (isKeyCodeBack(keyCode)) {
+			if (mediaController.isShowing()) {
 				mediaController.hide();
-
-				if (isMediaPlayerStateValid() && mediaPlayer.isPlaying()) {
-					mediaPlayer.stop();
-				}
-				setExitResultCode();
-				finish();
-				return true;
 			}
-
-			if (keyCode == KeyEvent.KEYCODE_MEDIA_NEXT) {
-				mediaController.hide();
-				if (isMediaPlayerStateValid() && mediaPlayer.isPlaying()) {
-					mediaPlayer.stop();
-				}
-
-				finish();
-				return true;
-			}
-		} else {
-			if (isKeyCodeBack(keyCode)) {
-				if (isMediaPlayerStateValid() && mediaPlayer.isPlaying()) {
-					mediaPlayer.stop();
-				}
-				setExitResultCode();
-				finish();
-				return true;
-			}
-		}
-
-		if (keyCode == KeyEvent.KEYCODE_MEDIA_NEXT) {
 			if (isMediaPlayerStateValid() && mediaPlayer.isPlaying()) {
 				mediaPlayer.stop();
 			}
+			setExitResultCode();
 			finish();
 			return true;
 		}
@@ -456,32 +432,58 @@ public class SerenitySurfaceViewVideoActivity extends SerenityActivity
 			}
 		}
 
-		if (isKeyCodeSkipForward(keyCode) && isMediaPlayerStateValid()) {
-			int skipOffset = 10000 + mediaPlayer.getCurrentPosition();
-			int duration = mediaPlayer.getDuration();
-			if (skipOffset > duration) {
-				skipOffset = duration - 1;
+		final String nextPrevBehavior = prefs.getString("next_prev_behavior", "queue");
+
+		if (keyCode == KeyEvent.KEYCODE_MEDIA_NEXT) {
+			if (nextPrevBehavior.equals("queue")) {
+				mediaController.hide();
+				if (isMediaPlayerStateValid() && mediaPlayer.isPlaying()) {
+					mediaPlayer.stop();
+				}
+				finish();
+				return true;
 			}
-			if (!mediaController.isShowing()) {
-				mediaController.show(CONTROLLER_DELAY);
+			final int skipTo;
+			if (isMediaPlayerStateValid()) {
+				if (nextPrevBehavior.endsWith("%")) {
+					final Integer percent = Integer.valueOf(nextPrevBehavior.substring(0, nextPrevBehavior.length() - 1));
+					skipTo = currentPosition + duration * percent / 100;
+				} else {
+					skipTo = currentPosition + Integer.valueOf(nextPrevBehavior);
+				}
+				skipToOffset(skipTo);
+				return true;
 			}
-			mediaPlayer.seekTo(skipOffset);
+		}
+
+		// All actions from here on require media to be in a valid state
+		if (!isMediaPlayerStateValid()) {
+			return super.onKeyDown(keyCode, event);
+		}
+
+		if (keyCode == KeyEvent.KEYCODE_MEDIA_PREVIOUS && !nextPrevBehavior.equals("queue")) {
+			final int skipTo;
+			if (nextPrevBehavior.endsWith("%")) {
+				final Integer percent = Integer.valueOf(nextPrevBehavior.substring(0, nextPrevBehavior.length() - 1));
+				skipTo = currentPosition - duration * percent / 100;
+			} else {
+				skipTo = currentPosition - Integer.valueOf(nextPrevBehavior);
+			}
+			skipToOffset(skipTo);
 			return true;
 		}
 
-		if (isKeyCodeSkipBack(keyCode) && isMediaPlayerStateValid()) {
-			int skipOffset = mediaPlayer.getCurrentPosition() - 10000;
-			if (skipOffset < 0) {
-				skipOffset = 0;
-			}
-			if (!mediaController.isShowing()) {
-				mediaController.show(CONTROLLER_DELAY);
-			}
-			mediaPlayer.seekTo(skipOffset);
+		if (isKeyCodeSkipForward(keyCode)) {
+			skipToOffset(currentPosition + Integer.valueOf(prefs.getString("skip_forward_time", "30000")));
 			return true;
 		}
 
-		if (isKeyCodeStop(keyCode) && isMediaPlayerStateValid()) {
+		if (isKeyCodeSkipBack(keyCode)) {
+			skipToOffset(currentPosition - Integer.valueOf(prefs.getString("skip_backward_time", "10000")));
+			return true;
+		}
+
+		if (isKeyCodeStop(keyCode)) {
 			if (mediaPlayer.isPlaying()) {
 				mediaPlayer.pause();
 				if (!mediaController.isShowing()) {
@@ -491,21 +493,31 @@ public class SerenitySurfaceViewVideoActivity extends SerenityActivity
 			return true;
 		}
 
-        if (keyCode == KeyEvent.KEYCODE_T) {
-            final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-            final boolean showTimeOfDay = !prefs.getBoolean("showTimeOfDay", false);
-            timeOfDayView.setVisibility(showTimeOfDay ? View.VISIBLE : View.GONE);
-            prefs.edit().putBoolean("showTimeOfDay", showTimeOfDay).apply();
-            return true;
-        }
+		if (keyCode == KeyEvent.KEYCODE_T) {
+			final boolean showTimeOfDay = !prefs.getBoolean("showTimeOfDay", false);
+			timeOfDayView.setVisibility(showTimeOfDay ? View.VISIBLE : View.GONE);
+			prefs.edit().putBoolean("showTimeOfDay", showTimeOfDay).apply();
+			return true;
+		}
 
-		if (isMediaPlayerStateValid()) {
-			if (isSkipByPercentage(keyCode)) {
-				return true;
-			}
+		if (isSkipByPercentage(keyCode)) {
+			return true;
 		}
 
 		return super.onKeyDown(keyCode, event);
+	}
+
+	private void skipToOffset(int skipOffset) {
+		int duration = mediaPlayer.getDuration();
+		if (skipOffset > duration) {
+			skipOffset = duration - 1;
+		} else if (skipOffset < 0) {
+			skipOffset = 0;
+		}
+		if (!mediaController.isShowing()) {
+			mediaController.show(CONTROLLER_DELAY);
+		}
+		mediaPlayer.seekTo(skipOffset);
 	}
 
 	protected boolean isSkipByPercentage(int keyCode) {
@@ -590,8 +602,8 @@ public class SerenitySurfaceViewVideoActivity extends SerenityActivity
 	@Override
 	protected boolean isKeyCodeSkipBack(int keyCode) {
 		return keyCode == KeyEvent.KEYCODE_MEDIA_REWIND
-				|| keyCode == KeyEvent.KEYCODE_MEDIA_PREVIOUS
 				|| keyCode == KeyEvent.KEYCODE_R
+				|| keyCode == KeyEvent.KEYCODE_MEDIA_PREVIOUS
 				|| keyCode == KeyEvent.KEYCODE_BUTTON_L1;
 	}
 


### PR DESCRIPTION
Add settings to control how these buttons work.
FF & REW can be configured to skip 10 sec, 30 sec, 1 min or 3 min.
NEXT & PREV can be configured to either skip 5%, 10%, 5 min and 10 min or retain their old behavior of NEXT skipping to next item on queue and PREV doing the same as REW
