### PR TITLE
Don't Reload in onResume

### DIFF
--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/tv/TVShowBrowserActivity.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/tv/TVShowBrowserActivity.java
@@ -117,7 +117,7 @@ public class TVShowBrowserActivity extends SerenityMultiViewVideoActivity {
 	protected void onResume() {
 		super.onResume();
 		populateMenuDrawer();
-		if (!restarted_state || "unwatched".equals(savedCategory)) {
+		if (!restarted_state) {
 			categoryHandler = new CategoryHandler(this);
 			Messenger messenger = new Messenger(categoryHandler);
 			Intent categoriesIntent = new Intent(this,
@@ -128,7 +128,7 @@ public class TVShowBrowserActivity extends SerenityMultiViewVideoActivity {
 		}
 
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see us.nineworlds.serenity.ui.activity.SerenityActivity#onKeyDown(int, android.view.KeyEvent)
 	 */


### PR DESCRIPTION
Because the selected item is lost. Need to find a proper way of making
the grid view refresh. Probably in onActivityResult.
