### PR TITLE
Add a Setting Button To Setup Overscan Compensation

### DIFF
--- a/serenity-app/AndroidManifest.xml
+++ b/serenity-app/AndroidManifest.xml
@@ -124,6 +124,8 @@
                 android:resource="@xml/searchable" />
         </activity>
 
+        <activity android:name=".ui.activity.OverscanSetupActivity"/>
+
         <service android:name=".core.services.MainMenuIntentService" />
         <service android:name=".core.services.MusicRetrievalIntentService" />
         <service android:name=".core.services.MusicAlbumRetrievalIntentService" />

--- a/serenity-app/res/layout-large/overscan_setup.xml
+++ b/serenity-app/res/layout-large/overscan_setup.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:background="@color/holo_color">
+    <RelativeLayout android:id="@+id/center"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_margin="30dp"
+                    android:background="@android:color/black">
+        <Button android:id="@+id/swap"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerHorizontal="true"
+                android:layout_alignParentBottom="true"
+                android:layout_marginLeft="20dp"
+                android:layout_marginBottom="30dp"
+                android:textSize="30sp"
+                android:text="@string/overscan_swap"/>
+        <TextView
+                android:layout_width="500dp"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:layout_centerHorizontal="true"
+                android:textSize="25sp"
+                android:text="@string/overscan_instructions"/>
+    </RelativeLayout>
+
+</LinearLayout>

--- a/serenity-app/res/values/strings.xml
+++ b/serenity-app/res/values/strings.xml
@@ -141,6 +141,7 @@
     <string name="preference_remote_control">Remote Control</string>
     <string name="overscan_adjustement_summary">Adjusts the screen so that items are not cut off.  May be necessary when running on OUYA or other Android TV devices.</string>
     <string name="overscan_compensation">Overscan Compensation</string>
+    <string name="overscan_setup_title">Overscan Compensation Setup</string>
     <string name="display_adjustements">Display Adjustements</string>
     <string name="add_season_to_queue">Add season to queue</string>
     <string name="season_options">Season Options</string>
@@ -191,6 +192,10 @@
     <string name="skip_backward_time_summary">Time to skip backward when REW button is pressed</string>
     <string name="next_prev_behavior_title">Next/Prev button behavior</string>
     <string name="next_prev_behavior_summary"><![CDATA[What should the Next & Prev buttons do]]></string>
+    <string name="overscan_swap">Swap sides</string>
+    <string name="overscan_instructions">Use D-Pad to adjust top-left, and bottom-right until no blue is visible. Use
+        button to swap sides.
+    </string>
 
     <string-array name="skipListNames">
         <item>10 Seconds</item>

--- a/serenity-app/res/xml/preferences.xml
+++ b/serenity-app/res/xml/preferences.xml
@@ -41,6 +41,9 @@
             android:key="overscan_compensation"
             android:summary="@string/overscan_adjustement_summary"
             android:title="@string/overscan_compensation" />
+        <Preference
+            android:key="overscan_setup"
+            android:title="@string/overscan_setup_title" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/music_library" >
         <CheckBoxPreference

--- a/serenity-app/src/main/java/us/nineworlds/serenity/MainActivity.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/MainActivity.java
@@ -26,8 +26,6 @@ package us.nineworlds.serenity;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.simonvt.menudrawer.MenuDrawer;
-
 import us.nineworlds.serenity.core.ServerConfig;
 import us.nineworlds.serenity.core.menus.MenuDrawerItem;
 import us.nineworlds.serenity.core.menus.MenuDrawerItemImpl;
@@ -36,41 +34,34 @@ import us.nineworlds.serenity.core.services.GDMService;
 import us.nineworlds.serenity.ui.activity.SerenityActivity;
 import us.nineworlds.serenity.ui.adapters.MenuDrawerAdapter;
 import us.nineworlds.serenity.ui.listeners.MenuDrawerOnClickListener;
+import us.nineworlds.serenity.ui.util.DisplayUtils;
+
+import android.app.Activity;
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.*;
+import android.content.SharedPreferences.Editor;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Message;
 import android.preference.PreferenceManager;
-import android.app.Activity;
-import android.app.Notification;
-import android.app.NotificationManager;
-import android.app.PendingIntent;
-import android.content.BroadcastReceiver;
-import android.content.ComponentName;
-import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
-import android.content.ServiceConnection;
-import android.content.SharedPreferences;
-import android.content.SharedPreferences.Editor;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.FrameLayout;
 import android.widget.Gallery;
 import android.widget.ListView;
-import android.widget.RelativeLayout;
 import android.widget.Toast;
-
-import us.nineworlds.serenity.R;
 
 import com.castillo.dd.DSInterface;
 import com.castillo.dd.Download;
 import com.castillo.dd.DownloadService;
 import com.castillo.dd.PendingDownload;
 import com.google.analytics.tracking.android.EasyTracker;
+import net.simonvt.menudrawer.MenuDrawer;
 
 public class MainActivity extends SerenityActivity {
 
@@ -340,16 +331,11 @@ public class MainActivity extends SerenityActivity {
 		}
 
 		initDownloadService();
-		
-		if (preferences.getBoolean("overscan_compensation", false)) {
-			RelativeLayout mainLayout = (RelativeLayout) findViewById(R.id.mainLayout);
-			FrameLayout.LayoutParams params = (FrameLayout.LayoutParams)  mainLayout.getLayoutParams();
-			params.setMargins(35, 20, 20, 20);
-			
-			RelativeLayout menuDrawerLayout = (RelativeLayout) findViewById(R.id.menu_drawer_layout);
-			FrameLayout.LayoutParams menuParams = (FrameLayout.LayoutParams)  menuDrawerLayout.getLayoutParams();
-			menuParams.setMargins(35, 0, 0, 0);
-		}
+
+		DisplayUtils.overscanCompensation(
+				this,
+				findViewById(R.id.mainLayout),
+				findViewById(R.id.menu_drawer_layout));
 
 
 	}

--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/activity/OverscanSetupActivity.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/activity/OverscanSetupActivity.java
@@ -1,0 +1,105 @@
+// Copyright 2013 Google Inc. All Rights Reserved.
+
+package us.nineworlds.serenity.ui.activity;
+
+import android.app.Activity;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import net.simonvt.menudrawer.R;
+
+public class OverscanSetupActivity extends Activity implements View.OnKeyListener, View.OnClickListener {
+
+	private View centerView;
+	private boolean topLeft = true;
+	private SharedPreferences prefs;
+
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+
+		requestWindowFeature(Window.FEATURE_NO_TITLE);
+		prefs = PreferenceManager.getDefaultSharedPreferences(this);
+
+		setContentView(R.layout.overscan_setup);
+		centerView = findViewById(R.id.center);
+		final View swapView = findViewById(R.id.swap);
+
+		final ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) centerView.getLayoutParams();
+		layoutParams.setMargins(
+				prefs.getInt("overscan_left", 50),
+				prefs.getInt("overscan_top", 50),
+				prefs.getInt("overscan_right", 50),
+				prefs.getInt("overscan_bottom", 50));
+		centerView.requestLayout();
+		swapView.setOnKeyListener(this);
+		swapView.setOnClickListener(this);
+	}
+
+	@Override
+	public boolean onKey(View v, int keyCode, KeyEvent event) {
+		if (event.getAction() != KeyEvent.ACTION_DOWN) {
+			return false;
+		}
+		final ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) centerView.getLayoutParams();
+		int top = layoutParams.topMargin;
+		int bottom = layoutParams.bottomMargin;
+		int left = layoutParams.leftMargin;
+		int right = layoutParams.rightMargin;
+		switch (keyCode) {
+			case KeyEvent.KEYCODE_DPAD_UP:
+				if (topLeft) {
+					top--;
+				} else {
+					bottom++;
+				}
+				break;
+
+			case KeyEvent.KEYCODE_DPAD_DOWN:
+				if (topLeft) {
+					top++;
+				} else {
+					bottom--;
+				}
+				break;
+
+			case KeyEvent.KEYCODE_DPAD_LEFT:
+				if (topLeft) {
+					left--;
+				} else {
+					right++;
+				}
+				break;
+
+			case KeyEvent.KEYCODE_DPAD_RIGHT:
+				if (topLeft) {
+					left++;
+				} else {
+					right--;
+				}
+				break;
+
+			default:
+				return false;
+		}
+		prefs.edit()
+				.putInt("overscan_top", top)
+				.putInt("overscan_left", left)
+				.putInt("overscan_bottom", bottom)
+				.putInt("overscan_right", right)
+				.apply();
+
+		layoutParams.setMargins(left, top, right, bottom);
+		centerView.requestLayout();
+		return true;
+	}
+
+	@Override
+	public void onClick(View v) {
+		topLeft = !topLeft;
+	}
+}

--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/movie/MovieBrowserActivity.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/movie/MovieBrowserActivity.java
@@ -26,32 +26,28 @@ package us.nineworlds.serenity.ui.browser.movie;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.simonvt.menudrawer.MenuDrawer;
-
+import us.nineworlds.serenity.R;
 import us.nineworlds.serenity.core.menus.MenuDrawerItem;
 import us.nineworlds.serenity.core.menus.MenuDrawerItemImpl;
 import us.nineworlds.serenity.core.services.CategoryRetrievalIntentService;
-import us.nineworlds.serenity.core.util.VolleyUtils;
 import us.nineworlds.serenity.ui.activity.CategoryHandler;
 import us.nineworlds.serenity.ui.activity.SerenityMultiViewVideoActivity;
 import us.nineworlds.serenity.ui.adapters.MenuDrawerAdapter;
 import us.nineworlds.serenity.ui.listeners.MenuDrawerOnClickListener;
-import us.nineworlds.serenity.R;
-import us.nineworlds.serenity.SerenityApplication;
+import us.nineworlds.serenity.ui.util.DisplayUtils;
 
-import com.android.volley.RequestQueue;
-import com.google.analytics.tracking.android.EasyTracker;
+import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Messenger;
 import android.preference.PreferenceManager;
-import android.content.Intent;
-import android.content.SharedPreferences;
 import android.view.KeyEvent;
 import android.view.View;
-import android.widget.FrameLayout;
 import android.widget.ListView;
-import android.widget.RelativeLayout;
+
+import com.google.analytics.tracking.android.EasyTracker;
+import net.simonvt.menudrawer.MenuDrawer;
 
 public class MovieBrowserActivity extends SerenityMultiViewVideoActivity {
 
@@ -144,17 +140,11 @@ public class MovieBrowserActivity extends SerenityMultiViewVideoActivity {
 				
 		key = getIntent().getExtras().getString("key");
 		createSideMenu();
-		if (prefs.getBoolean("overscan_compensation", false)) {
-			RelativeLayout mainLayout = (RelativeLayout) findViewById(R.id.movieBrowserBackgroundLayout);
-			FrameLayout.LayoutParams params = (FrameLayout.LayoutParams)  mainLayout.getLayoutParams();
-			params.setMargins(35, 20, 20, 20);
-			
-			RelativeLayout menuDrawerLayout = (RelativeLayout) findViewById(R.id.menu_drawer_layout);
-			FrameLayout.LayoutParams menuParams = (FrameLayout.LayoutParams)  menuDrawerLayout.getLayoutParams();
-			menuParams.setMargins(35, 0, 0, 0);
-			
-		}
 
+		DisplayUtils.overscanCompensation(
+				this,
+				findViewById(R.id.movieBrowserBackgroundLayout),
+				findViewById(R.id.menu_drawer_layout));
 	}
 
 	@Override

--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/music/MusicActivity.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/music/MusicActivity.java
@@ -44,6 +44,7 @@ import android.widget.ArrayAdapter;
 import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 import android.widget.Spinner;
+import us.nineworlds.serenity.ui.util.DisplayUtils;
 
 /**
  * @author dcarver
@@ -79,18 +80,15 @@ public class MusicActivity extends Activity {
 		} else {
 			setContentView(R.layout.activity_music_artist_gridview);
 		}
-		
-		if (prefs.getBoolean("overscan_compensation", false)) {
-			RelativeLayout mainLayout =  null;
-			if (MUSIC_GRIDVIEW) {
-				mainLayout = (RelativeLayout) findViewById(R.id.musicBrowserBackgroundLayout);
-			} else {
-				mainLayout = (RelativeLayout) findViewById(R.id.musicArtistBrowserLayout);
-			}
-			FrameLayout.LayoutParams params = (FrameLayout.LayoutParams)  mainLayout.getLayoutParams();
-			params.setMargins(35, 20, 20, 20);
-		}
 
+
+		final RelativeLayout mainLayout;
+		if (MUSIC_GRIDVIEW) {
+			mainLayout = (RelativeLayout) findViewById(R.id.musicBrowserBackgroundLayout);
+		} else {
+			mainLayout = (RelativeLayout) findViewById(R.id.musicArtistBrowserLayout);
+		}
+		DisplayUtils.overscanCompensation(this, mainLayout);
 	}
 
 	/*

--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/music/albums/MusicAlbumsActivity.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/music/albums/MusicAlbumsActivity.java
@@ -37,6 +37,7 @@ import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
+import us.nineworlds.serenity.ui.util.DisplayUtils;
 
 /**
  * @author dcarver
@@ -61,12 +62,9 @@ public class MusicAlbumsActivity extends Activity {
 		SharedPreferences prefs = PreferenceManager
 				.getDefaultSharedPreferences(this);
 		setContentView(R.layout.activity_music_artist_gridview);
-		if (prefs.getBoolean("overscan_compensation", false)) {
-			RelativeLayout mainLayout = (RelativeLayout) findViewById(R.id.musicBrowserBackgroundLayout);
-			FrameLayout.LayoutParams params = (FrameLayout.LayoutParams)  mainLayout.getLayoutParams();
-			params.setMargins(35, 20, 20, 20);
-		}
-		
+
+		DisplayUtils.overscanCompensation(this, findViewById(R.id.musicBrowserBackgroundLayout));
+
 		TextView category = (TextView)findViewById(R.id.musicCategoryName);
 		category.setVisibility(View.GONE);
 		Spinner categoryFilter = (Spinner)findViewById(R.id.musicCategoryFilter);

--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/music/tracks/MusicTracksActivity.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/music/tracks/MusicTracksActivity.java
@@ -58,6 +58,7 @@ import android.widget.RelativeLayout;
 import android.widget.SeekBar;
 import android.widget.TextView;
 import android.widget.Toast;
+import us.nineworlds.serenity.ui.util.DisplayUtils;
 
 /**
  * @author dcarver
@@ -176,12 +177,8 @@ public class MusicTracksActivity extends Activity implements
 		} else {
 			setContentView(R.layout.activity_music_track);
 		}
-		
-		if (prefs.getBoolean("overscan_compensation", false)) {
-			RelativeLayout mainLayout = (RelativeLayout) findViewById(R.id.musicBrowserBackgroundLayout);
-			FrameLayout.LayoutParams params = (FrameLayout.LayoutParams)  mainLayout.getLayoutParams();
-			params.setMargins(35, 20, 20, 20);
-		}
+
+		DisplayUtils.overscanCompensation(this, findViewById(R.id.musicBrowserBackgroundLayout));
 
 		init();
 	}

--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/tv/TVShowBrowserActivity.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/tv/TVShowBrowserActivity.java
@@ -58,6 +58,7 @@ import android.widget.Gallery;
 import android.widget.ListView;
 import android.widget.RelativeLayout;
 import android.widget.Spinner;
+import us.nineworlds.serenity.ui.util.DisplayUtils;
 
 /**
  * @author dcarver
@@ -77,17 +78,10 @@ public class TVShowBrowserActivity extends SerenityMultiViewVideoActivity {
 		preferences = PreferenceManager.getDefaultSharedPreferences(this);
 		
 		createSideMenu();
-		
-		if (preferences.getBoolean("overscan_compensation", false)) {
-			RelativeLayout mainLayout = (RelativeLayout) findViewById(R.id.tvshowBrowserLayout);
-			FrameLayout.LayoutParams params = (FrameLayout.LayoutParams)  mainLayout.getLayoutParams();
-			params.setMargins(35, 20, 40, 20);
-			
-			RelativeLayout menuDrawerLayout = (RelativeLayout) findViewById(R.id.menu_drawer_layout);
-			FrameLayout.LayoutParams menuParams = (FrameLayout.LayoutParams)  menuDrawerLayout.getLayoutParams();
-			menuParams.setMargins(35, 0, 0, 0);			
-		}
 
+		DisplayUtils.overscanCompensation(this,
+				findViewById(R.id.tvshowBrowserLayout),
+				findViewById(R.id.menu_drawer_layout));
 	}
 
 	@Override

--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/tv/episodes/EpisodeBrowserActivity.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/tv/episodes/EpisodeBrowserActivity.java
@@ -26,7 +26,7 @@ package us.nineworlds.serenity.ui.browser.tv.episodes;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.simonvt.menudrawer.MenuDrawer;
+import us.nineworlds.serenity.R;
 import us.nineworlds.serenity.core.menus.MenuDrawerItem;
 import us.nineworlds.serenity.core.menus.MenuDrawerItemImpl;
 import us.nineworlds.serenity.ui.activity.SerenityVideoActivity;
@@ -34,12 +34,8 @@ import us.nineworlds.serenity.ui.adapters.MenuDrawerAdapter;
 import us.nineworlds.serenity.ui.listeners.GalleryVideoOnItemClickListener;
 import us.nineworlds.serenity.ui.listeners.GalleryVideoOnItemLongClickListener;
 import us.nineworlds.serenity.ui.listeners.MenuDrawerOnClickListener;
+import us.nineworlds.serenity.ui.util.DisplayUtils;
 import us.nineworlds.serenity.widgets.SerenityGallery;
-
-import us.nineworlds.serenity.R;
-import us.nineworlds.serenity.SerenityApplication;
-
-import com.google.analytics.tracking.android.EasyTracker;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -47,9 +43,10 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.view.KeyEvent;
 import android.view.View;
-import android.widget.FrameLayout;
 import android.widget.ListView;
-import android.widget.RelativeLayout;
+
+import com.google.analytics.tracking.android.EasyTracker;
+import net.simonvt.menudrawer.MenuDrawer;
 
 public class EpisodeBrowserActivity extends SerenityVideoActivity {
 
@@ -97,16 +94,10 @@ public class EpisodeBrowserActivity extends SerenityVideoActivity {
 		metaData = findViewById(R.id.metaDataRow);
 		metaData.setVisibility(View.VISIBLE);
 		prefs = PreferenceManager.getDefaultSharedPreferences(this);
-		
-		if (prefs.getBoolean("overscan_compensation", false)) {
-			RelativeLayout mainLayout = (RelativeLayout) bgLayout;
-			FrameLayout.LayoutParams params = (FrameLayout.LayoutParams)  mainLayout.getLayoutParams();
-			params.setMargins(35, 20, 20, 20);
-			
-			RelativeLayout menuDrawerLayout = (RelativeLayout) findViewById(R.id.menu_drawer_layout);
-			FrameLayout.LayoutParams menuParams = (FrameLayout.LayoutParams)  menuDrawerLayout.getLayoutParams();
-			menuParams.setMargins(35, 0, 0, 0);
-		}
+
+		DisplayUtils.overscanCompensation(this,
+				bgLayout,
+				findViewById(R.id.menu_drawer_layout));
 
 	}
 	

--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/tv/seasons/TVShowSeasonBrowserActivity.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/browser/tv/seasons/TVShowSeasonBrowserActivity.java
@@ -33,6 +33,7 @@ import us.nineworlds.serenity.core.menus.MenuDrawerItemImpl;
 import us.nineworlds.serenity.ui.activity.SerenityVideoActivity;
 import us.nineworlds.serenity.ui.adapters.MenuDrawerAdapter;
 import us.nineworlds.serenity.ui.listeners.MenuDrawerOnClickListener;
+import us.nineworlds.serenity.ui.util.DisplayUtils;
 import us.nineworlds.serenity.widgets.SerenityGallery;
 
 import com.google.analytics.tracking.android.EasyTracker;
@@ -68,17 +69,10 @@ public class TVShowSeasonBrowserActivity extends SerenityVideoActivity {
 
 		tvShowSeasonsMainView = findViewById(R.id.tvshowSeasonBrowserLayout);
 		tvShowSeasonsGallery = (Gallery) findViewById(R.id.tvShowSeasonImageGallery);
-		if (PreferenceManager.getDefaultSharedPreferences(this).getBoolean(
-				"overscan_compensation", false)) {
-			FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) tvShowSeasonsMainView
-					.getLayoutParams();
-			params.setMargins(35, 20, 45, 20);
 
-			RelativeLayout menuDrawerLayout = (RelativeLayout) findViewById(R.id.menu_drawer_layout);
-			FrameLayout.LayoutParams menuParams = (FrameLayout.LayoutParams) menuDrawerLayout
-					.getLayoutParams();
-			menuParams.setMargins(35, 0, 0, 0);
-		}
+		DisplayUtils.overscanCompensation(this,
+				tvShowSeasonsMainView,
+				findViewById(R.id.menu_drawer_layout));
 	}
 
 	@Override

--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/preferences/SerenityPreferenceActivity.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/preferences/SerenityPreferenceActivity.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 
+import android.preference.Preference;
 import us.nineworlds.serenity.MainActivity;
 import us.nineworlds.serenity.SerenityApplication;
 
@@ -46,6 +47,8 @@ import android.content.pm.ResolveInfo;
 import android.os.Bundle;
 import android.preference.ListPreference;
 import android.preference.PreferenceActivity;
+import us.nineworlds.serenity.ui.activity.OverscanSetupActivity;
+import us.nineworlds.serenity.ui.util.DisplayUtils;
 
 /**
  * This is the main activity for managing user preferences in the app.
@@ -53,12 +56,13 @@ import android.preference.PreferenceActivity;
  * @author dcarver
  * 
  */
-public class SerenityPreferenceActivity extends PreferenceActivity {
+public class SerenityPreferenceActivity extends PreferenceActivity implements Preference.OnPreferenceClickListener {
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		addPreferencesFromResource(R.xml.preferences);
+		findPreference("overscan_setup").setOnPreferenceClickListener(this);
 	}
 
 	/*
@@ -205,6 +209,15 @@ public class SerenityPreferenceActivity extends PreferenceActivity {
 		}
 
 		return false;		
-	}	
+	}
 
+	@Override
+	public boolean onPreferenceClick(Preference preference) {
+		final String key = preference.getKey();
+		if ("overscan_setup".equals(key)) {
+			startActivity(new Intent(this, OverscanSetupActivity.class));
+			return true;
+		}
+		return false;
+	}
 }

--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/util/DisplayUtils.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/util/DisplayUtils.java
@@ -24,8 +24,14 @@
 package us.nineworlds.serenity.ui.util;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.util.DisplayMetrics;
 import android.view.Display;
+import android.view.View;
+import android.view.ViewGroup;
+
 
 /**
  * @author dcarver
@@ -52,6 +58,20 @@ public class DisplayUtils {
 	    int dpWidth  = Float.valueOf(outMetrics.heightPixels / density).intValue();
 	    return dpWidth;
 	}
-	
+
+	public static void overscanCompensation(Context context, View... views) {
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+		if (prefs.getBoolean("overscan_compensation", false)) {
+			for (View view : views) {
+				ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams)  view.getLayoutParams();
+				params.setMargins(
+						prefs.getInt("overscan_left", 50),
+						prefs.getInt("overscan_top", 50),
+						prefs.getInt("overscan_right", 50),
+						prefs.getInt("overscan_bottom", 50));
+			}
+		}
+	}
 	
 }

--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/video/player/SerenitySurfaceViewVideoActivity.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/video/player/SerenitySurfaceViewVideoActivity.java
@@ -70,6 +70,7 @@ import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 import android.widget.Toast;
+import us.nineworlds.serenity.ui.util.DisplayUtils;
 
 /**
  * A view that handles the internal video playback and representation of a movie
@@ -228,18 +229,14 @@ public class SerenitySurfaceViewVideoActivity extends SerenityActivity
 		videoActivityView = findViewById(R.id.video_playeback);
 		timeOfDayView = findViewById(R.id.time_of_day);
 
-		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-		if (prefs.getBoolean("overscan_compensation", false)) {
-			FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) videoActivityView
-					.getLayoutParams();
-			params.setMargins(35, 20, 20, 20);
-		}
+		DisplayUtils.overscanCompensation(this, videoActivityView);
 
 		surfaceView.setKeepScreenOn(true);
 		SurfaceHolder holder = surfaceView.getHolder();
 		holder.addCallback(this);
 		holder.setSizeFromLayout();
 
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
 		final boolean showTimeOfDay = prefs.getBoolean("showTimeOfDay", false);
 		timeOfDayView.setVisibility(showTimeOfDay ? View.VISIBLE : View.GONE);
 


### PR DESCRIPTION
This new activity alows the user to adjust the overscan compensation to be used so that
it matches exactly what his screen uses.

Change all activities that used a hardcoded setup to the proper setup.

A side affect of this is that some activities layout now seem to be a bit off.

Also, I was not able to adjust the overscan for the Preferences Activity. The problem
is that I can't find the proper view to adjust for. Using getListView() doesn't work.
