### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
    - pip install --user codecov
 
 script:
-   - travis_wait 60 ./gradlew clean jacocoTestReport sonarqube
+   - ./gradlew clean jacocoTestReport sonarqube
    
 after_success:
   - codecov


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
