### PR TITLE
feat: Implement Jellyfin Client based on the Emby Client implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ build
 keystore.properties
 .settings
 emby-lib/cache
+*/build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ Intended audience:
 - NEVER amend commits unless you have explicit written approval in the task thread.
 - Coordinate with other agents before reverting or deleting work you did not author.
 - Always double-check `git status` before committing.
+- ALWAYS ask before proceeding.
+- NEVER go beyond your existing requested tasks.
+- DO NOT try to fix other errors or issues outside of your current task.
 
 ---
 

--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/adapters/MediaContainerAdaptor.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/adapters/MediaContainerAdaptor.kt
@@ -177,9 +177,9 @@ class MediaContainerAdaptor {
 
       if (item.mediaStreams != null) {
         val medias = ArrayList<Media>()
-        val media = Media()
-        media.container = item.container
         for (mediaStream in item.mediaStreams) {
+          val media = Media()
+          media.container = item.container
           if (mediaStream.type == "Video") {
             media.aspectRatio = mediaStream.aspectRatio
             media.videoCodec = mediaStream.codec

--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/EmbyServerDiscover.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/EmbyServerDiscover.kt
@@ -94,14 +94,14 @@ class EmbyServerDiscover {
 
         val servers = ArrayList<Server>()
 
-        while (timeoutMs > 0) {
+        while (timeout > 0) {
 
             val startTime = System.currentTimeMillis()
 
             // Wait for a response
             val recvBuf = ByteArray(15000)
             val receivePacket = DatagramPacket(recvBuf, recvBuf.size)
-            c.soTimeout = timeoutMs.toInt()
+            c.soTimeout = timeout.toInt()
 
             try {
                 c.receive(receivePacket)
@@ -122,7 +122,7 @@ class EmbyServerDiscover {
 
             val server = EmbyServer()
             val uri = URI.create(embyServerInfo!!.remoteAddres)
-            Timber.d("Server Remote Address: ${embyServerInfo!!.remoteAddres}")
+            Timber.d("Server Remote Address: ${embyServerInfo.remoteAddres}")
             Timber.d("Server host: ${uri.host}")
 
             server.ipAddress = uri.host
@@ -137,8 +137,7 @@ class EmbyServerDiscover {
             // TODO: Once completely migrated to the ServerChannel remove the event bus.
             eventBus.post(server)
 
-            val endTime = System.currentTimeMillis()
-            timeout -= (endTime - startTime)
+            timeout -= (System.currentTimeMillis() - startTime)
         }
 
         Timber.d("Found %d servers", servers.size)

--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClient.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClient.kt
@@ -10,6 +10,7 @@ import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.joda.time.LocalDateTime
+import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import timber.log.Timber
@@ -27,6 +28,7 @@ import us.nineworlds.serenity.emby.server.model.PublicUserInfo
 import us.nineworlds.serenity.emby.server.model.QueryFilters
 import us.nineworlds.serenity.emby.server.model.QueryResult
 import java.io.File
+import java.io.IOException
 import java.util.UUID
 
 class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:8096") : SerenityClient {
@@ -77,7 +79,7 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
 
     fun fetchAllPublicUsers(): List<PublicUserInfo> {
         val allPublicUsers = usersService.allPublicUsers()
-        return allPublicUsers.execute().body()!!
+        return allPublicUsers.executeOrThrow()
     }
 
     fun userImageUrl(userId: String): String {
@@ -87,22 +89,19 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
     fun authenticate(userName: String, password: String = ""): AuthenticationResult {
         val authenticationResul = AuthenticateUserByName(userName, "", password, password)
         val call = usersService.authenticate(authenticationResul, headerMap())
-        val response = call.execute()
-        if (response.isSuccessful) {
-            val body = response.body()
-            accessToken = body!!.accesToken
-            serverId = body.serverId
-            userId = body.userInfo.id!!
+        val body = call.executeOrThrow()
 
-            val prefEditor = prefs.edit()
+        accessToken = body.accesToken
+        serverId = body.serverId
+        userId = body.userInfo.id!!
 
-            prefEditor.putString("userId", userId)
-            prefEditor.putString("embyAccessToken", accessToken)
-            prefEditor.apply()
+        val prefEditor = prefs.edit()
 
-            return response.body()!!
-        }
-        throw IllegalStateException("error logging user in to Emby Server")
+        prefEditor.putString("userId", userId)
+        prefEditor.putString("embyAccessToken", accessToken)
+        prefEditor.apply()
+
+        return body
     }
 
     fun currentUserViews(): QueryResult {
@@ -110,7 +109,7 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
             userId = fetchUserId()
         }
         val call = usersService.usersViews(headerMap(), userId!!)
-        return call.execute().body()!!
+        return call.executeOrThrow()
     }
 
     fun filters(itemId: String? = null, tags: List<String>? = null): QueryFilters {
@@ -118,7 +117,7 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
             userId = fetchUserId()
         }
         val call = filterService.availableFilters(headerMap(), userId!!)
-        return call.execute().body()!!
+        return call.executeOrThrow()
     }
 
     override fun fetchItemById(itemId: String): IMediaContainer {
@@ -140,7 +139,7 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
         }
         val call = usersService.fetchItem(headerMap(), userId!!, id)
 
-        return call.execute().body()!!
+        return call.executeOrThrow()
     }
 
     fun fetchItemQuery(id: String): QueryResult {
@@ -149,7 +148,7 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
         }
         val call = usersService.fetchItemQuery(headerMap(), userId!!, id, genre = null)
 
-        return call.execute().body()!!
+        return call.executeOrThrow()
     }
 
     private fun headerMap(): Map<String, String> {
@@ -199,9 +198,9 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
 
         val call = usersService.usersViews(headerMap(), userId!!)
 
-        val queryResult = call.execute().body()
+        val queryResult = call.executeOrThrow()
 
-        return MediaContainerAdaptor().createMainMenu(queryResult!!.items)
+        return MediaContainerAdaptor().createMainMenu(queryResult.items)
     }
 
     override fun retrieveLibrary(): IMediaContainer {
@@ -217,9 +216,9 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
         }
         val call = usersService.usersViews(headerMap(), userId!!)
 
-        val queryResult = call.execute().body()
+        val queryResult = call.executeOrThrow()
 
-        return MediaContainerAdaptor().createMainMenu(queryResult!!.items)
+        return MediaContainerAdaptor().createMainMenu(queryResult.items)
     }
 
     override fun retrieveCategoriesById(key: String): IMediaContainer {
@@ -228,9 +227,9 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
         }
         val call = filterService.availableFilters(headerMap(), userId = userId!!, itemId = key)
 
-        val queryResult = call.execute().body()
+        val queryResult = call.executeOrThrow()
 
-        return MediaContainerAdaptor().createCategory(queryResult!!.genres!!)
+        return MediaContainerAdaptor().createCategory(queryResult.genres!!)
     }
 
     override fun retrieveItemByIdCategory(key: String, category: String, types: Types): IMediaContainer {
@@ -247,8 +246,8 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
 
         val call = usersService.fetchSimilarItemById(headerMap(), itemId = itemId, userId = userId!!, includeItemType = "Movie")
 
-        val results = call.execute().body()
-        return MediaContainerAdaptor().createVideoList(results!!.items)
+        val results = call.executeOrThrow()
+        return MediaContainerAdaptor().createVideoList(results.items)
     }
 
     override fun retrieveItemByIdCategory(key: String, category: String, types: Types, startIndex: Int, limit: Int?): IMediaContainer {
@@ -302,8 +301,8 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
             }
         }
 
-        val results = call.execute().body()
-        return MediaContainerAdaptor().createVideoList(results!!.items)
+        val results = call.executeOrThrow()
+        return MediaContainerAdaptor().createVideoList(results.items)
     }
 
     override fun retrieveItemByCategories(key: String, category: String, secondaryCategory: String): IMediaContainer {
@@ -322,9 +321,9 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
                 genre = null
         )
 
-        val results = call.execute().body()
+        val results = call.executeOrThrow()
 
-        return MediaContainerAdaptor().createSeriesList(results!!.items)
+        return MediaContainerAdaptor().createSeriesList(results.items)
     }
 
     override fun retrieveMusicMetaData(key: String): IMediaContainer {
@@ -343,9 +342,9 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
                 genre = null
         )
 
-        val results = call.execute().body()
+        val results = call.executeOrThrow()
 
-        return MediaContainerAdaptor().createVideoList(results!!.items)
+        return MediaContainerAdaptor().createVideoList(results.items)
     }
 
     override fun retrieveMovieMetaData(key: String): IMediaContainer {
@@ -357,10 +356,10 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
             userId = fetchUserId()
         }
         val call = usersService.search(headerMap(), userId!!, query)
-        val results = call.execute().body()
+        val results = call.executeOrThrow()
         val itemIds = mutableListOf<String>()
 
-        for (searchHint in results!!.searchHints!!) {
+        for (searchHint in results.searchHints!!) {
             itemIds.add(searchHint.id!!)
         }
 
@@ -372,9 +371,9 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
                 parentId = null
         )
 
-        val itemResults = itemCall.execute().body()
+        val itemResults = itemCall.executeOrThrow()
 
-        return MediaContainerAdaptor().createVideoList(itemResults!!.items)
+        return MediaContainerAdaptor().createVideoList(itemResults.items)
     }
 
     override fun searchEpisodes(key: String, query: String): IMediaContainer? {
@@ -461,7 +460,7 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
             startOffset = offset.toLong().times(10000)
         }
 
-        return "${baseUrl}emby/Videos/$id/stream.mkv?DeviceId=$deviceId&AudioCodec=aac&VideoCodec=h264&CopyTimeStamps=true&EnableAutoStreamCopy=true&StartTimeTicks=$startOffset&PlaySessionId=$playSessionId"
+        return "${baseUrl}Videos/$id/stream.mkv?DeviceId=$deviceId&AudioCodec=aac&VideoCodec=h264&CopyTimeStamps=true&EnableAutoStreamCopy=true&StartTimeTicks=$startOffset&PlaySessionId=$playSessionId"
     }
 
     override fun reinitialize() {
@@ -469,7 +468,7 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
     }
 
     override fun createUserImageUrl(user: SerenityUser, width: Int, height: Int): String {
-        return "$baseUrl/Emby/Users/${user.userId}/Images/Primary?Width=$width&Height=$height"
+        return "$baseUrl/Users/${user.userId}/Images/Primary?Width=$width&Height=$height"
     }
 
     override fun startPlaying(itemId: String) {
@@ -516,8 +515,8 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
                 limitCount = 5
         )
 
-        val results = call.execute().body()
-        return MediaContainerAdaptor().createSeriesList(results!!.items)
+        val results = call.executeOrThrow()
+        return MediaContainerAdaptor().createSeriesList(results.items)
     }
 
     override fun retrieveSeriesCategoryById(key: String): IMediaContainer {
@@ -526,9 +525,9 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
         }
         val call = filterService.availableFilters(headerMap(), userId!!, key)
 
-        val queryResult = call.execute().body()
+        val queryResult = call.executeOrThrow()
 
-        return MediaContainerAdaptor().createCategory(queryResult!!.genres!!, true)
+        return MediaContainerAdaptor().createCategory(queryResult.genres!!, true)
     }
 
     fun fetchUserId() = prefs.getString("userId", "")
@@ -574,6 +573,15 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
 
         // Finally, combine the values we have found by using the UUID class to create a unique identifier
         return UUID(devIDShort.hashCode().toLong(), serial.hashCode().toLong()).toString()
+    }
+
+    private fun <T> Call<T>.executeOrThrow(): T {
+        val response = execute()
+        if (response.isSuccessful) {
+            return response.body()
+                ?: throw IOException("Response from Emby was null. Response Code: ${response.code()} - ${response.message()}")
+        }
+        throw IOException("Request to Emby failed with code ${response.code()}, message: ${response.message()}")
     }
 
 }

--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/model/usersmodel.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/model/usersmodel.kt
@@ -16,7 +16,7 @@ data class PublicUserInfo(
 
 data class AuthenticateUserByName(
   @Json(name = "Username") val username: String,
-  @Json(name = "PassowrdMd5") val passwordMD5: String,
+  @Json(name = "PasswordMd5") val passwordMD5: String,
   @Json(name = "Password") val password: String,
   @Json(name = "Pw") val pw: String
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,10 @@ androidxRecyclerViewVersion = "1.4.0"
 resourcefulVersion = "1.1.0"
 mockkVersion = "1.14.6"
 turbine = "1.2.0"
+agpVersion = "8.13.1"
+kotlin = "2.2.21"
+coreKtxVersion = "1.10.1"
+espressoCoreVersion = "3.5.1"
 
 [libraries]
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotationVersion" }
@@ -134,7 +138,11 @@ kotlin-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coro
 toothpick-testing = { group = "com.github.stephanenicolas.toothpick", name = "toothpick-testing", version.ref = "toothPickVersion"}
 assertk-jvm = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertkJvmVersion" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine"}
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtxVersion" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCoreVersion" }
 
 [plugins]
 ksp = { id = "com.google.devtools.ksp", version.ref = "kotlinKSPVersion" }
+android-application = { id = "com.android.application", version.ref = "agpVersion" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 

--- a/jellyfin-lib/build.gradle.kts
+++ b/jellyfin-lib/build.gradle.kts
@@ -1,0 +1,92 @@
+plugins {
+  id("com.android.library")
+  kotlin("android")
+  kotlin("kapt")
+  id("com.google.devtools.ksp")
+}
+
+android {
+  namespace = "us.nineworlds.serenity.jellyfin"
+  buildFeatures {
+    buildConfig = true
+  }
+  defaultConfig {
+    minSdkVersion(libs.versions.minSdkVersion.get())
+    targetSdkVersion(libs.versions.targetSdkVersion.get())
+  }
+
+  compileSdk = libs.versions.targetSdkVersion.get().toInt()
+  testOptions {
+    unitTests {
+      isIncludeAndroidResources = true
+    }
+  }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+  }
+
+  sourceSets {
+    getByName("main").java.srcDirs("src/main/kotlin", "src/main/java")
+    getByName("test").java.srcDirs("src/test/kotlin")
+  }
+
+  buildTypes {
+    getByName("debug") {
+      buildConfigField("String", "CLIENT_VERSION", "\"${libs.versions.appVersion.get()}\"")
+    }
+
+    getByName("release") {
+      buildConfigField("String", "CLIENT_VERSION", "\"${libs.versions.appVersion.get()}\"")
+    }
+  }
+}
+
+dependencies {
+  api(project(":serenity-common"))
+  api(project(":serenity-android-common"))
+  api(project(":manager"))
+
+  implementation(libs.kotlin)
+  implementation(libs.kotlin.coroutines.android)
+  implementation(libs.kotlin.coroutines.core)
+
+
+  releaseApi(libs.toothpick.runtime) {
+    exclude(group = "javax.inject")
+  }
+  releaseApi(libs.toothpick.smoothie) {
+    exclude(group = "javax.inject")
+  }
+
+  debugImplementation(libs.toothpick.runtime)
+  debugImplementation(libs.toothpick.smoothie)
+
+  releaseApi(libs.toothpick.javax.annotations)
+  ksp(libs.toothpick.ksp.compiler)
+
+  implementation(libs.eventbus)
+  implementation(libs.moshi)
+  implementation(libs.retrofit.moshi)
+  implementation(libs.joda.time)
+  implementation(libs.retrofit)
+  implementation(libs.okhttp)
+  implementation(libs.okhttp.logging.interceptor)
+  implementation(libs.timber)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.assertj.core)
+  testImplementation(libs.assertk.jvm)
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.mockk)
+  testImplementation(libs.robolectric)
+  testImplementation(libs.robolectric.shadows.framework)
+  testImplementation(libs.opengl.api)
+  testImplementation(libs.androidx.test.core)
+  testImplementation(libs.kotlin.coroutines.test)
+
+  testImplementation(libs.toothpick.testing)
+  kspTest(libs.toothpick.ksp.compiler)
+  testImplementation(libs.turbine)
+}

--- a/jellyfin-lib/src/main/AndroidManifest.xml
+++ b/jellyfin-lib/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+</manifest>

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/adapters/JellyfinMediaContainerAdaptor.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/adapters/JellyfinMediaContainerAdaptor.kt
@@ -1,0 +1,202 @@
+package us.nineworlds.serenity.jellyfin.adapters
+
+import us.nineworlds.serenity.common.media.model.IDirectory
+import us.nineworlds.serenity.common.media.model.IMediaContainer
+import us.nineworlds.serenity.jellyfin.model.Directory
+import us.nineworlds.serenity.jellyfin.model.Media
+import us.nineworlds.serenity.jellyfin.model.MediaContainer
+import us.nineworlds.serenity.jellyfin.model.Video
+import us.nineworlds.serenity.jellyfin.server.model.Item
+import us.nineworlds.serenity.jellyfin.server.model.NameGuidPair
+
+class JellyfinMediaContainerAdaptor {
+
+  companion object {
+    const val TICKS_PER_MILLISECOND: Long = 10000
+  }
+
+  fun createMainMenu(items: List<Item>): IMediaContainer {
+    val mediaContainer = MediaContainer()
+    val directories = ArrayList<Directory>()
+    for (item in items) {
+      val entry = Directory()
+      entry.title = item.name
+      entry.type = item.collectionType
+      entry.key = item.id
+      directories.add(entry)
+    }
+
+    mediaContainer.directories = directories.toList()
+    return mediaContainer
+  }
+
+  fun createCategory(genres: List<NameGuidPair>, series: Boolean? = false): IMediaContainer {
+    val mediaContainer = MediaContainer()
+    val directories = ArrayList<Directory>()
+
+    directories.add(createAllCatagory())
+    if (series == false) {
+      directories.add(createUnwatched())
+      directories.add(createRecentlyAddedCategory())
+      directories.add(createOnDeck())
+    }
+
+    for (genre in genres) {
+      val entry = Directory()
+      entry.title = genre.name
+      entry.key = genre.name
+      entry.secondary = 0
+      directories.add(entry)
+    }
+
+    mediaContainer.directories = directories.toList()
+
+    return mediaContainer
+  }
+
+  fun createAllCatagory(): Directory {
+    val allCategory = Directory()
+    allCategory.title = "All"
+    allCategory.key = "all"
+    return allCategory
+  }
+
+  fun createUnwatched(): Directory {
+    val allCategory = Directory()
+    allCategory.title = "Unwatched"
+    allCategory.key = "unwatched"
+    return allCategory
+  }
+
+  fun createRecentlyAddedCategory(): Directory {
+    val allCategory = Directory()
+    allCategory.title = "Recently Added"
+    allCategory.key = "recentlyAdded"
+    return allCategory
+  }
+
+  fun createOnDeck(): Directory {
+    val allCategory = Directory()
+    allCategory.title = "OnDeck"
+    allCategory.key = "ondeck"
+    return allCategory
+  }
+
+  fun createSeriesList(series: List<Item>): IMediaContainer {
+    val mediaContainer = MediaContainer()
+    val seriesVideos = ArrayList<IDirectory>()
+
+    for (item in series) {
+      val seriesEntry = Directory()
+
+      seriesEntry.title = item.name
+      seriesEntry.summary = item.oveview
+      seriesEntry.key = item.id
+      seriesEntry.contentRating = item.officialRating
+      seriesEntry.rating = (item.communityRating ?: 0.00).toString()
+
+      var totalItemCount = 0L
+      var viewdItemsCount = 0L
+      if (item.userData != null) {
+        if (item.userData.unplayedItemCount != null) {
+          totalItemCount += item.userData.unplayedItemCount
+        }
+
+        if (item.userData.playCount != null) {
+          viewdItemsCount = item.userData.playCount
+          totalItemCount += viewdItemsCount
+        }
+      }
+
+      seriesEntry.leafCount = totalItemCount.toString()
+      seriesEntry.viewedLeafCount = viewdItemsCount.toString()
+
+      seriesEntry.art = "/Items/${item.id}/Images/Thumb"
+      seriesEntry.thumb = "/Items/${item.id}/Images/Primary"
+      seriesEntry.banner = "/Items/${item.id}/Images/Banner"
+
+      seriesVideos.add(seriesEntry)
+    }
+    mediaContainer.directories = seriesVideos
+    mediaContainer.size = series.size
+
+    return mediaContainer
+  }
+
+  fun createSeaonsList(seaons: List<Item>): IMediaContainer {
+    return MediaContainer()
+  }
+
+  fun createVideoList(videos: List<Item>): IMediaContainer {
+    val mediaContainer = MediaContainer()
+    val serenityVideos = ArrayList<Video>()
+    mediaContainer.size = videos.size
+
+    val items = videos.filter { item -> item.type != "Folder"  }
+                      .filterNot { item -> item.name == "TBA" }
+
+    for (item in items) {
+      val video = Video()
+
+      val sortEpisode = item.episodeNumber?.toInt() ?: 0
+
+      video.type = item.type
+      video.titleSort = sortEpisode.toString().padStart(3, '0')
+      video.title = item.name
+      video.key = item.id
+      video.parentKey = item.parentId
+      video.contentRating = item.officialRating
+      video.summary = item.oveview
+      video.rating = item.communityRating ?: 0.00
+      video.season = item.parentIndexNumber
+      video.seriesName = item.seriesName
+
+      if (item.type != null && item.type == "Episode") {
+        video.backgroundImageKey = "/Items/${item.parentId}/Images/Backdrop"
+        video.parentThumbNailImageKey = "/Items/${item.parentId}/Images/Primary"
+      } else {
+        video.backgroundImageKey = "/Items/${item.id}/Images/Backdrop"
+      }
+      video.thumbNailImageKey = "/Items/${item.id}/Images/Primary"
+      video.viewCount = item.userData?.playCount?.toInt() ?: 0
+      val offset = convertTicksToMilliseconds(item.userData?.playbackPositionTicks ?: 0)
+      video.viewOffset = offset
+      video.episode = item.episodeNumber
+
+      val container = if (item.container != null && item.container.contains(",")) {
+        item.container.substringBefore(",")
+      } else {
+        item.container
+      }
+      video.directPlayUrl = "Videos/${item.mediaSources?.get(0)?.id ?: item.id}/stream.$container?static=true"
+
+      if (item.runTimeTicks != null) {
+        val milliseconds = convertTicksToMilliseconds(item.runTimeTicks)
+        video.duration = milliseconds
+      }
+
+      if (item.mediaStreams != null) {
+        val medias = ArrayList<Media>()
+        val media = Media()
+        media.container = item.container
+        for (mediaStream in item.mediaStreams) {
+          if (mediaStream.type == "Video") {
+            media.aspectRatio = mediaStream.aspectRatio
+            media.videoCodec = mediaStream.codec
+          } else if (mediaStream.type == "Audio") {
+            media.audioCodec = mediaStream.codec
+            media.audioChannels = mediaStream.channels
+          }
+          medias.add(media)
+        }
+        video.medias = medias.toList()
+      }
+
+      serenityVideos.add(video)
+    }
+    mediaContainer.videos = serenityVideos.sortedBy { item -> item.titleSort } .toList()
+    return mediaContainer
+  }
+
+  fun convertTicksToMilliseconds(ticks: Long): Long = ticks.div(TICKS_PER_MILLISECOND)
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/adapters/JellyfinMediaContainerAdaptor.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/adapters/JellyfinMediaContainerAdaptor.kt
@@ -177,9 +177,9 @@ class JellyfinMediaContainerAdaptor {
 
       if (item.mediaStreams != null) {
         val medias = ArrayList<Media>()
-        val media = Media()
-        media.container = item.container
         for (mediaStream in item.mediaStreams) {
+          val media = Media()
+          media.container = item.container
           if (mediaStream.type == "Video") {
             media.aspectRatio = mediaStream.aspectRatio
             media.videoCodec = mediaStream.codec

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/AbstractCrew.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/AbstractCrew.kt
@@ -1,0 +1,16 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.ICrew
+
+abstract class AbstractCrew : ICrew {
+    private var _tag: String? = null
+
+    override fun getTag(): String? {
+        return _tag
+    }
+
+    override fun setTag(tag: String?) {
+        _tag = tag
+    }
+
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/AbstractJellyfinClientObject.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/AbstractJellyfinClientObject.kt
@@ -1,0 +1,15 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.ClientObject
+
+abstract class AbstractJellyfinClientObject : ClientObject {
+
+    private var _key : String? = null
+
+    override fun getKey(): String? = _key
+
+    override fun setKey(key: String?) {
+        _key = key
+    }
+
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Country.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Country.kt
@@ -1,0 +1,5 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.ICountry
+
+class Country : AbstractCrew(), ICountry

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Director.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Director.kt
@@ -1,0 +1,5 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.IDirector
+
+class Director : AbstractCrew(), IDirector

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Directory.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Directory.kt
@@ -1,0 +1,168 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.IDirectory
+import us.nineworlds.serenity.common.media.model.IGenre
+import us.nineworlds.serenity.common.media.model.ILocation
+
+class Directory : IDirectory {
+    private var _thumb: String? = null
+    private var _banner: String? = null
+    private var _secondary: Int = 0
+    private var _genres: List<IGenre>? = null
+    private var _ratingKey: String? = null
+    private var _studio: String? = null
+    private var _rating: String? = null
+    private var _year: String? = null
+    private var _contentRating: String? = null
+    private var _summary: String? = null
+    private var _leafCount: String? = null
+    private var _viewedLeafCount: String? = null
+    private var _title: String? = null
+    private var _art: String? = null
+    private var _refreshing: Int = 0
+    private var _type: String? = null
+    private var _agent: String? = null
+    private var _scanner: String? = null
+    private var _language: String? = null
+    private var _uuid: String? = null
+    private var _updatedAt: Long = 0
+    private var _createdAt: Long = 0
+    private var _prompt: String? = null
+    private var _search: String? = null
+    private var _locations: List<ILocation>? = null
+    private var _key: String? = null
+
+    override fun getThumb(): String? = _thumb
+    override fun setThumb(thumb: String?) {
+        _thumb = thumb
+    }
+
+    override fun getBanner(): String? = _banner
+    override fun setBanner(banner: String?) {
+        _banner = banner
+    }
+
+    override fun getSecondary(): Int = _secondary
+    override fun setSecondary(secondary: Int) {
+        _secondary = secondary
+    }
+
+    override fun getGenres(): List<IGenre>? = _genres
+    override fun setGenres(genres: List<IGenre>?) {
+        _genres = genres
+    }
+
+    override fun getRatingKey(): String? = _ratingKey
+    override fun setRatingKey(ratingKey: String?) {
+        _ratingKey = ratingKey
+    }
+
+    override fun getStudio(): String? = _studio
+    override fun setStudio(studio: String?) {
+        _studio = studio
+    }
+
+    override fun getRating(): String? = _rating
+    override fun setRating(rating: String?) {
+        _rating = rating
+    }
+
+    override fun getYear(): String? = _year
+    override fun setYear(year: String?) {
+        _year = year
+    }
+
+    override fun getContentRating(): String? = _contentRating
+    override fun setContentRating(contentRating: String?) {
+        _contentRating = contentRating
+    }
+
+    override fun getSummary(): String? = _summary
+    override fun setSummary(summary: String?) {
+        _summary = summary
+    }
+
+    override fun getLeafCount(): String? = _leafCount
+    override fun setLeafCount(leafCount: String?) {
+        _leafCount = leafCount
+    }
+
+    override fun getViewedLeafCount(): String? = _viewedLeafCount
+    override fun setViewedLeafCount(viewedLeafCount: String?) {
+        this._viewedLeafCount = viewedLeafCount
+    }
+
+    override fun getTitle(): String? = _title
+    override fun setTitle(title: String?) {
+        _title = title
+    }
+
+    override fun getArt(): String? = _art
+    override fun setArt(art: String?) {
+        _art = art
+    }
+
+    override fun getRefreshing(): Int = _refreshing
+    override fun setRefreshing(refreshing: Int) {
+        _refreshing = refreshing
+    }
+
+    override fun getType(): String? = _type
+    override fun setType(type: String?) {
+        _type = type
+    }
+
+    override fun getAgent(): String? = _agent
+    override fun setAgent(agent: String?) {
+        _agent = agent
+    }
+
+    override fun getScanner(): String? = _scanner
+    override fun setScanner(scanner: String?) {
+        _scanner = scanner
+    }
+
+    override fun getLanguage(): String? = _language
+    override fun setLanguage(language: String?) {
+        _language = language
+    }
+
+    override fun getUuid(): String? = _uuid
+    override fun setUuid(uuid: String?) {
+        _uuid = uuid
+    }
+
+    override fun getUpdatedAt(): Long = _updatedAt
+    override fun setUpdatedAt(updatedAt: Long) {
+        _updatedAt = updatedAt
+    }
+
+    override fun getCreatedAt(): Long = _createdAt
+    override fun setCreatedAt(createdAt: Long) {
+        _createdAt = createdAt
+    }
+
+    override fun getLocations(): List<ILocation>? = _locations
+    override fun setLocation(location: List<ILocation>?) {
+        _locations = location
+    }
+
+    override fun getPrompt(): String? = _prompt
+    override fun setPrompt(prompt: String?) {
+        _prompt = prompt
+    }
+
+    override fun getSearch(): String? = _search
+    override fun setSearch(search: String?) {
+        this._search = search
+    }
+
+    override fun setLocations(locations: List<ILocation>?) {
+        _locations = locations
+    }
+
+    override fun getKey(): String? = _key
+    override fun setKey(key: String?) {
+        _key = key
+    }
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Genre.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Genre.kt
@@ -1,0 +1,5 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.IGenre
+
+class Genre : AbstractCrew(), IGenre

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Location.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Location.kt
@@ -1,0 +1,15 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.ILocation
+
+class Location : ILocation {
+    private var _path: String? = null
+
+    override fun getPath(): String? {
+        return _path
+    }
+
+    override fun setPath(path: String?) {
+        _path = path
+    }
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Media.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Media.kt
@@ -1,0 +1,56 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.IMedia
+import us.nineworlds.serenity.common.media.model.IPart
+
+class Media : IMedia {
+    private var _aspectRatio: String? = null
+    private var _audioCodec: String? = null
+    private var _videoCodec: String? = null
+    private var _videoResolution: String? = null
+    private var _container: String? = null
+    private var _audioChannels: String? = null
+    private var _videoParts: List<IPart>? = null
+
+    override fun getAudioChannels(): String? = _audioChannels
+
+    override fun setAudioChannels(audioChannels: String?) {
+        _audioChannels = audioChannels
+    }
+
+    override fun getContainer(): String? = _container
+
+    override fun setContainer(container: String?) {
+        _container = container
+    }
+
+    override fun getVideoPart(): List<IPart>? = _videoParts
+
+    override fun setVideoPart(videoParts: List<IPart>?) {
+        _videoParts = videoParts
+    }
+
+    override fun getAspectRatio(): String? = _aspectRatio
+
+    override fun setAspectRatio(aspectRatio: String?) {
+        _aspectRatio = aspectRatio
+    }
+
+    override fun getAudioCodec(): String? = _audioCodec
+
+    override fun setAudioCodec(audioCodec: String?) {
+        _audioCodec = audioCodec
+    }
+
+    override fun getVideoCodec(): String? = _videoCodec
+
+    override fun setVideoCodec(videoCodec: String?) {
+        _videoCodec = videoCodec
+    }
+
+    override fun getVideoResolution(): String? = _videoResolution
+
+    override fun setVideoResolution(videoResolution: String?) {
+        _videoResolution = videoResolution
+    }
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/MediaContainer.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/MediaContainer.kt
@@ -1,0 +1,115 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.IDirectory
+import us.nineworlds.serenity.common.media.model.IMediaContainer
+import us.nineworlds.serenity.common.media.model.ITrack
+import us.nineworlds.serenity.common.media.model.IVideo
+
+class MediaContainer : IMediaContainer {
+    private var _title1: String? = null
+    private var _title2: String? = null
+    private var _directories: List<IDirectory>? = null
+    private var _size: Int = 0
+    private var _allowSync: Int = 0
+    private var _identifier: String? = null
+    private var _mediaTagPrefix: String? = null
+    private var _mediaTagVersion: Long = 0
+    private var _videos: List<IVideo>? = null
+    private var _art: String? = null
+    private var _sortAsc: Int = 0
+    private var _content: String? = null
+    private var _viewGroup: String? = null
+    private var _viewMode: Int = 0
+    private var _parentPosterUrl: String? = null
+    private var _tracks: List<ITrack>? = null
+    private var _parentIndex: String? = null
+
+    override fun getTitle1(): String? = _title1
+    override fun setTitle1(title1: String?) {
+        _title1 = title1
+    }
+
+    override fun getTitle2(): String? = _title2
+    override fun setTitle2(title2: String?) {
+        _title2 = title2
+    }
+
+    override fun getDirectories(): List<IDirectory>? = _directories
+    override fun setDirectories(directory: List<IDirectory>?) {
+        _directories = directory
+    }
+
+    override fun getSize(): Int = _size
+    override fun setSize(size: Int) {
+        _size = size
+    }
+
+    override fun getAllowSync(): Int = _allowSync
+    override fun setAllowSync(allowSync: Int) {
+        _allowSync = allowSync
+    }
+
+    override fun getIdentifier(): String? = _identifier
+    override fun setIdentifier(identifier: String?) {
+        _identifier = identifier
+    }
+
+    override fun getMediaTagPrefix(): String? = _mediaTagPrefix
+    override fun setMediaTagPrefix(mediaTagPrefix: String?) {
+        _mediaTagPrefix = mediaTagPrefix
+    }
+
+    override fun getMediaTagVersion(): Long = _mediaTagVersion
+    override fun setMediaTagVersion(mediaTagVersion: Long) {
+        _mediaTagVersion = mediaTagVersion
+    }
+
+    override fun setMediaTagVersion(mediaTagVersion: Int) {
+        this.mediaTagVersion = mediaTagVersion.toLong()
+    }
+
+    override fun getArt(): String? = _art
+    override fun setArt(art: String?) {
+        _art = art
+    }
+
+    override fun getSortAsc(): Int = _sortAsc
+    override fun setSortAsc(sortAsc: Int) {
+        _sortAsc = sortAsc
+    }
+
+    override fun getContent(): String? = _content
+    override fun setContent(content: String?) {
+        _content = content
+    }
+
+    override fun getViewGroup(): String? = _viewGroup
+    override fun setViewGroup(viewGroup: String?) {
+        _viewGroup = viewGroup
+    }
+
+    override fun getViewMode(): Int = _viewMode
+    override fun setViewMode(viewMode: Int) {
+        _viewMode = viewMode
+    }
+
+    override fun getVideos(): List<IVideo>? = _videos
+    override fun setVideos(videos: List<IVideo>?) {
+        _videos = videos
+    }
+
+    override fun getParentPosterURL(): String? = _parentPosterUrl
+    override fun setParentPosterURL(parentPosterURL: String?) {
+        _parentPosterUrl = parentPosterURL
+    }
+
+    override fun getTracks(): List<ITrack>? = _tracks
+    override fun setTracks(tracks: List<ITrack>?) {
+        _tracks = tracks
+    }
+
+    override fun getParentIndex(): String? = _parentIndex
+    override fun setParentIndex(parentIndex: String?) {
+        _parentIndex = parentIndex
+    }
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Part.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Part.kt
@@ -1,0 +1,35 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.IPart
+import us.nineworlds.serenity.common.media.model.IStream
+
+class Part : IPart {
+    private var _key: String? = null
+    private var _filename: String? = null
+    private var _container: String? = null
+    private var _streams: List<IStream>? = null
+
+    override fun getStreams(): List<IStream>? = _streams
+
+    override fun setStreams(streams: List<IStream>?) {
+        _streams = streams
+    }
+
+    override fun getContainer(): String? = _container
+
+    override fun setContainer(container: String?) {
+        _container = container
+    }
+
+    override fun getKey(): String? = _key
+
+    override fun setKey(key: String?) {
+        _key = key
+    }
+
+    override fun getFilename(): String? = _filename
+
+    override fun setFilename(filename: String?) {
+        _filename = filename
+    }
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Role.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Role.kt
@@ -1,0 +1,5 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.IRole
+
+class Role : AbstractCrew(), IRole

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Stream.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Stream.kt
@@ -1,0 +1,90 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.IStream
+
+class Stream : IStream {
+    private var _id: Int = 0
+    private var _streamType: Int = 0
+    private var _codec: String? = null
+    private var _index: String? = null
+    private var _channels: String? = null
+    private var _duration: String? = null
+    private var _bitrate: String? = null
+    private var _bitrateMode: String? = null
+    private var _profile: String? = null
+    private var _optimizedForStreaming: String? = null
+    private var _format: String? = null
+    private var _key: String? = null
+    private var _language: String? = null
+    private var _languageCode: String? = null
+
+    override fun getLanguage(): String? = _language
+    override fun setLanguage(language: String?) {
+        _language = language
+    }
+
+    override fun getLanguageCode(): String? = _languageCode
+    override fun setLanguageCode(languageCode: String?) {
+        _languageCode = languageCode
+    }
+
+    override fun getId(): Int = _id
+    override fun setId(id: Int) {
+        _id = id
+    }
+
+    override fun getStreamType(): Int = _streamType
+    override fun setStreamType(streamType: Int) {
+        _streamType = streamType
+    }
+
+    override fun getCodec(): String? = _codec
+    override fun setCodec(codec: String?) {
+        _codec = codec
+    }
+
+    override fun getIndex(): String? = _index
+    override fun setIndex(index: String?) {
+        _index = index
+    }
+
+    override fun getChannels(): String? = _channels
+    override fun setChannels(channels: String?) {
+        _channels = channels
+    }
+
+    override fun getDuration(): String? = _duration
+    override fun setDuration(duration: String?) {
+        _duration = duration
+    }
+
+    override fun getBitrate(): String? = _bitrate
+    override fun setBitrate(bitrate: String?) {
+        _bitrate = bitrate
+    }
+
+    override fun getBitrateMode(): String? = _bitrateMode
+    override fun setBitrateMode(bitrateMode: String?) {
+        _bitrateMode = bitrateMode
+    }
+
+    override fun getProfile(): String? = _profile
+    override fun setProfile(profile: String?) {
+        _profile = profile
+    }
+
+    override fun getOptimizedForStreaming(): String? = _optimizedForStreaming
+    override fun setOptimizedForStreaming(optimizedForStreaming: String?) {
+        _optimizedForStreaming = optimizedForStreaming
+    }
+
+    override fun getFormat(): String? = _format
+    override fun setFormat(format: String?) {
+        _format = format
+    }
+
+    override fun getKey(): String? = _key
+    override fun setKey(key: String?) {
+        _key = key
+    }
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Video.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Video.kt
@@ -1,0 +1,204 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.ICountry
+import us.nineworlds.serenity.common.media.model.IDirector
+import us.nineworlds.serenity.common.media.model.IGenre
+import us.nineworlds.serenity.common.media.model.IMedia
+import us.nineworlds.serenity.common.media.model.IRole
+import us.nineworlds.serenity.common.media.model.IVideo
+import us.nineworlds.serenity.common.media.model.IWriter
+
+class Video : AbstractJellyfinClientObject(), IVideo {
+    private var _type: String? = null
+    private var _studio: String? = null
+    private var _summary: String? = null
+    private var _titleSort: String? = null
+    private var _title: String? = null
+    private var _viewCount: Int = 0
+    private var _tagLine: String? = null
+    private var _viewOffset: Long = 0
+    private var _thumbNailImageKey: String? = null
+    private var _backgroundImageKey: String? = null
+    private var _parentThumbNailImageKey: String? = null
+    private var _grandParentThumbNailImageKey: String? = null
+    private var _grandParentTitle: String? = null
+    private var _duration: Long = 0
+    private var _timeAdded: Long = 0
+    private var _timeUpdated: Long = 0
+    private var _originallyAvailableDate: String? = null
+    private var _contentRating: String? = null
+    private var _year: String? = null
+    private var _ratingKey: String? = null
+    private var _parentKey: String? = null
+    private var _episode: String? = null
+    private var _season: String? = null
+    private var _rating: Double = 0.0
+    private var _countries: List<ICountry>? = null
+    private var _directors: List<IDirector>? = null
+    private var _actors: List<IRole>? = null
+    private var _writers: List<IWriter>? = null
+    private var _genres: List<IGenre>? = null
+    private var _medias: List<IMedia>? = null
+    private var _directPlayUrl: String? = null
+    private var _seriesName: String? = null
+
+    override fun getSeriesName(): String? = _seriesName
+    override fun setSeriesName(seriesName: String?) {
+        _seriesName = seriesName
+    }
+
+    override fun getType(): String? = _type
+    override fun setType(type: String?) {
+        _type = type
+    }
+
+    override fun getGrandParentTitle(): String? = _grandParentTitle
+    override fun setGrandParentTitle(grandParentTitle: String?) {
+        _grandParentTitle = grandParentTitle
+    }
+
+    override fun getGrandParentThumbNailImageKey(): String? = _grandParentThumbNailImageKey
+    override fun setGrandParentThumbNailImageKey(grandParentThumbNailImageKey: String?) {
+        _grandParentThumbNailImageKey = grandParentThumbNailImageKey
+    }
+
+    override fun getActors(): List<IRole>? = _actors
+    override fun setActors(actors: List<IRole>?) {
+        _actors = actors
+    }
+
+    override fun getBackgroundImageKey(): String? = _backgroundImageKey
+    override fun setBackgroundImageKey(backgroundImageKey: String?) {
+        _backgroundImageKey = backgroundImageKey
+    }
+
+    override fun getContentRating(): String? = _contentRating
+    override fun setContentRating(contentRating: String?) {
+        _contentRating = contentRating
+    }
+
+    override fun getCountries(): List<ICountry>? = _countries
+    override fun setCountries(countries: List<ICountry>?) {
+        _countries = countries
+    }
+
+    override fun getDirectors(): List<IDirector>? = _directors
+    override fun setDirectors(directors: List<IDirector>?) {
+        _directors = directors
+    }
+
+    override fun getDuration(): Long = _duration
+    override fun setDuration(duration: Long) {
+        _duration = duration
+    }
+
+    override fun getGenres(): List<IGenre>? = _genres
+    override fun setGenres(genres: List<IGenre>?) {
+        _genres = genres
+    }
+
+    override fun getMedias(): List<IMedia>? = _medias
+    override fun setMedias(medias: List<IMedia>?) {
+        _medias = medias
+    }
+
+    override fun getOriginallyAvailableDate(): String? = _originallyAvailableDate
+    override fun setOriginallyAvailableDate(originallyAvailableDate: String?) {
+        _originallyAvailableDate = originallyAvailableDate
+    }
+
+    override fun getSummary(): String? = _summary
+    override fun setSummary(summary: String?) {
+        _summary = summary
+    }
+
+    override fun getTagLine(): String? = _tagLine
+    override fun setTagLine(tagLine: String?) {
+        _tagLine = tagLine
+    }
+
+    override fun getThumbNailImageKey(): String? = _thumbNailImageKey
+    override fun setThumbNailImageKey(thumbNailImageKey: String?) {
+        _thumbNailImageKey = thumbNailImageKey
+    }
+
+    override fun getTimeAdded(): Long = _timeAdded
+    override fun setTimeAdded(timeAdded: Long) {
+        _timeAdded = timeAdded
+    }
+
+    override fun getTimeUpdated(): Long = _timeUpdated
+    override fun setTimeUpdated(timeUpdated: Long) {
+        _timeUpdated = timeUpdated
+    }
+
+    override fun getTitle(): String? = _title
+    override fun setTitle(title: String?) {
+        _title = title
+    }
+
+    override fun getTitleSort(): String? = _titleSort
+    override fun setTitleSort(titleSort: String?) {
+        _titleSort = titleSort
+    }
+
+    override fun getViewCount(): Int = _viewCount
+    override fun setViewCount(viewCount: Int) {
+        _viewCount = viewCount
+    }
+
+    override fun getViewOffset(): Long = _viewOffset
+    override fun setViewOffset(viewOffset: Long) {
+        _viewOffset = viewOffset
+    }
+
+    override fun getWriters(): List<IWriter>? = _writers
+    override fun setWriters(writers: List<IWriter>?) {
+        _writers = writers
+    }
+
+    override fun getYear(): String? = _year
+    override fun setYear(year: String?) {
+        _year = year
+    }
+
+    override fun getRatingKey(): String? = _ratingKey
+    override fun setRatingKey(ratingKey: String?) {
+        _ratingKey = ratingKey
+    }
+
+    override fun getParentThumbNailImageKey(): String? = _parentThumbNailImageKey
+    override fun setParentThumbNailImageKey(parentThumbNailImageKey: String?) {
+        _parentThumbNailImageKey = parentThumbNailImageKey
+    }
+
+    override fun getStudio(): String? = _studio
+    override fun setStudio(studio: String?) {
+        _studio = studio
+    }
+
+    override fun getRating(): Double = _rating
+    override fun setRating(rating: Double) {
+        _rating = rating
+    }
+
+    override fun getParentKey(): String? = _parentKey
+    override fun setParentKey(parentKey: String?) {
+        _parentKey = parentKey
+    }
+
+    override fun getEpisode(): String? = _episode
+    override fun setEpisode(episode: String?) {
+        _episode = episode
+    }
+
+    override fun getSeason(): String? = _season
+    override fun setSeason(season: String?) {
+        _season = season
+    }
+
+    override fun getDirectPlayUrl(): String? = _directPlayUrl
+    override fun setDirectPlayUrl(directPlayUrl: String?) {
+        _directPlayUrl = directPlayUrl
+    }
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Writer.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/model/Writer.kt
@@ -1,0 +1,5 @@
+package us.nineworlds.serenity.jellyfin.model
+
+import us.nineworlds.serenity.common.media.model.IWriter
+
+class Writer : AbstractCrew(), IWriter

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/moshi/LocalDateJsonAdapter.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/moshi/LocalDateJsonAdapter.kt
@@ -1,0 +1,26 @@
+package us.nineworlds.serenity.jellyfin.moshi
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import org.joda.time.LocalDateTime
+import org.joda.time.format.DateTimeFormat
+
+class LocalDateJsonAdapter : JsonAdapter<LocalDateTime>() {
+  override fun fromJson(reader: JsonReader): LocalDateTime? {
+
+    val dateTime = reader.nextString()!!.replaceAfter(".", "")
+    val dateformater = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH':'mm':'ss'.'")
+//      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSS'Z'")
+//    } else if(dateTime!!.contains("+")) {
+//    } else {
+//      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ")
+//    }
+
+    return LocalDateTime.parse(dateTime, dateformater)
+  }
+
+  override fun toJson(writer: JsonWriter, value: LocalDateTime?) {
+    writer.value(value?.toString())
+  }
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/JellyfinServer.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/JellyfinServer.kt
@@ -1,0 +1,55 @@
+package us.nineworlds.serenity.jellyfin.server
+
+import us.nineworlds.serenity.common.Server
+import java.io.Serializable
+
+class JellyfinServer : Server, Serializable {
+
+  private var serverName: String? = null
+  private var ipAddress: String? = ""
+  private var hostName: String? = null
+  private var discoveryProtocol: String? = "Jellyfin"
+  private var portNumber: String? = null
+
+  override fun setServerName(serverName: String?) {
+    this.serverName = serverName
+  }
+
+  override fun getIPAddress(): String? {
+    return ipAddress
+  }
+
+  override fun setIPAddress(ipaddress: String?) {
+    this.ipAddress = ipaddress
+  }
+
+  override fun getHostName(): String? {
+    return hostName
+  }
+
+  override fun setHostName(hostName: String?) {
+    this.hostName = hostName
+  }
+
+  override fun discoveryProtocol(): String? {
+    return discoveryProtocol
+  }
+
+  override fun setDiscoveryProtocol(protocol: String?) {
+    this.discoveryProtocol = protocol
+  }
+
+  override fun getServerName(): String? {
+    return serverName
+  }
+
+  override fun hasMultipleAccounts(): Boolean = true
+
+  override fun getPort(): String? {
+    return portNumber
+  }
+
+  override fun setPort(portNumber: String?) {
+    this.portNumber = portNumber
+  }
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/JellyfinServerDiscover.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/JellyfinServerDiscover.kt
@@ -1,0 +1,156 @@
+package us.nineworlds.serenity.jellyfin.server
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.greenrobot.eventbus.EventBus
+import timber.log.Timber
+import us.nineworlds.serenity.common.Server
+import us.nineworlds.serenity.common.channels.ServerChannel
+import java.io.IOException
+import java.net.*
+
+
+class JellyfinServerDiscover {
+
+    private val eventBus = EventBus.getDefault()
+    private val moshiBuilder = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+
+    suspend fun findServers() = withContext(Dispatchers.IO) {
+        try {
+            //Open a random port to send the package
+            val c = DatagramSocket()
+            c.setBroadcast(true)
+
+            val sendData = "who is JellyfinServer?".toByteArray()
+
+            val port = 7359
+
+            //Try the 255.255.255.255 first
+
+            try {
+                val sendPacket = DatagramPacket(
+                    sendData,
+                    sendData.size,
+                    InetAddress.getByName("255.255.255.255"),
+                    port
+                )
+                c.send(sendPacket)
+                Timber.d(">>> Request packet sent to: 255.255.255.255 (DEFAULT)")
+            } catch (e: Exception) {
+                Timber.e(e, "Error sending DatagramPacket")
+            }
+
+            try {
+                val sendPacket =
+                    DatagramPacket(sendData, sendData.size, useMultiCastAddress(), port)
+                c.send(sendPacket)
+            } catch (e: Exception) {
+                Timber.e(e, "error sending to multicast address")
+            }
+
+            // Broadcast the message over all the network interfaces
+            val interfaces = NetworkInterface.getNetworkInterfaces()
+            while (interfaces.hasMoreElements()) {
+                val networkInterface = interfaces.nextElement() as NetworkInterface
+
+                if (networkInterface.isLoopback() || !networkInterface.isUp()) {
+                    continue // Don't want to broadcast to the loopback interface
+                }
+
+                for (interfaceAddress in networkInterface.getInterfaceAddresses()) {
+                    val broadcast = interfaceAddress.getBroadcast() ?: continue
+
+                    // Send the broadcast package!
+                    try {
+                        val sendPacket = DatagramPacket(sendData, sendData.size, broadcast, port)
+                        c.send(sendPacket)
+                    } catch (e: Exception) {
+                        Timber.e(e, "Error sending DatagramPacket")
+                    }
+
+                    Timber.d(
+                        ">>> Request packet sent to: " + broadcast.getHostAddress() + "; Interface: " + networkInterface.getDisplayName()
+                    )
+                }
+            }
+
+            Timber.d(">>> Done looping over all network interfaces. Now waiting for a reply!")
+
+            receive(c, 8000L)
+
+            //Close the port!
+            c.close()
+        } catch (ex: Exception) {
+            Timber.e(ex, "Error finding servers")
+        }
+    }
+
+    @Throws(IOException::class)
+    private suspend fun receive(c: DatagramSocket, timeoutMs: Long) {
+
+        var timeout = timeoutMs
+
+        val servers = ArrayList<Server>()
+
+        while (timeoutMs > 0) {
+
+            val startTime = System.currentTimeMillis()
+
+            // Wait for a response
+            val recvBuf = ByteArray(15000)
+            val receivePacket = DatagramPacket(recvBuf, recvBuf.size)
+            c.soTimeout = timeoutMs.toInt()
+
+            try {
+                c.receive(receivePacket)
+            } catch (e: SocketTimeoutException) {
+                Timber.d("Server discovery timed out waiting for response.")
+                break
+            }
+
+            // We have a response
+            Timber.d(">>> Broadcast response from server: " + receivePacket.address.hostAddress)
+
+            // Check if the message is correct
+            val message = String(receivePacket.data).trim { it <= ' ' }
+
+            Timber.d(javaClass.name + ">>> Broadcast response from server: " + message)
+
+            val jellyfinServerInfo = moshiBuilder.adapter(JellyfinServerInfo::class.java).fromJson(message)
+
+            val server = JellyfinServer()
+            val uri = URI.create(jellyfinServerInfo!!.remoteAddres)
+            Timber.d("Server Remote Address: ${jellyfinServerInfo!!.remoteAddres}")
+            Timber.d("Server host: ${uri.host}")
+
+            server.ipAddress = uri.host
+            server.port = uri.port.toString()
+            Timber.d("Server Port: ${uri.port}")
+
+            server.serverName = "Jellyfin - " + jellyfinServerInfo.name
+
+            ServerChannel.invokeServerEvent(server)
+            servers.add(server)
+
+            // TODO: Once completely migrated to the ServerChannel remove the event bus.
+            eventBus.post(server)
+
+            val endTime = System.currentTimeMillis()
+            timeout -= (endTime - startTime)
+        }
+
+        Timber.d("Found %d servers", servers.size)
+    }
+
+    @Throws(IOException::class)
+    suspend fun useMultiCastAddress(): InetAddress {
+        return InetAddress.getByName(MULTICAST_ADDRESS)
+    }
+
+    companion object {
+        const val MULTICAST_ADDRESS = "239.255.255.250"
+    }
+
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/JellyfinServerDiscover.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/JellyfinServerDiscover.kt
@@ -94,14 +94,14 @@ class JellyfinServerDiscover {
 
         val servers = ArrayList<Server>()
 
-        while (timeoutMs > 0) {
+        while (timeout > 0) {
 
             val startTime = System.currentTimeMillis()
 
             // Wait for a response
             val recvBuf = ByteArray(15000)
             val receivePacket = DatagramPacket(recvBuf, recvBuf.size)
-            c.soTimeout = timeoutMs.toInt()
+            c.soTimeout = timeout.toInt()
 
             try {
                 c.receive(receivePacket)
@@ -122,7 +122,7 @@ class JellyfinServerDiscover {
 
             val server = JellyfinServer()
             val uri = URI.create(jellyfinServerInfo!!.remoteAddres)
-            Timber.d("Server Remote Address: ${jellyfinServerInfo!!.remoteAddres}")
+            Timber.d("Server Remote Address: ${jellyfinServerInfo.remoteAddres}")
             Timber.d("Server host: ${uri.host}")
 
             server.ipAddress = uri.host
@@ -137,8 +137,7 @@ class JellyfinServerDiscover {
             // TODO: Once completely migrated to the ServerChannel remove the event bus.
             eventBus.post(server)
 
-            val endTime = System.currentTimeMillis()
-            timeout -= (endTime - startTime)
+            timeout -= (System.currentTimeMillis() - startTime)
         }
 
         Timber.d("Found %d servers", servers.size)

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/JellyfinServerInfo.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/JellyfinServerInfo.kt
@@ -1,0 +1,9 @@
+package us.nineworlds.serenity.jellyfin.server
+
+import com.squareup.moshi.Json
+
+data class JellyfinServerInfo(
+  @Json(name = "Address") val remoteAddres: String,
+  @Json(name = "Id") val id: String,
+  @Json(name = "Name") val name: String
+)

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClient.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClient.kt
@@ -1,0 +1,579 @@
+package us.nineworlds.serenity.jellyfin.server.api
+
+import android.content.Context
+import android.os.Build
+import android.preference.PreferenceManager
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import me.jessyan.retrofiturlmanager.RetrofitUrlManager
+import okhttp3.Cache
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.joda.time.LocalDateTime
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import timber.log.Timber
+import us.nineworlds.serenity.common.media.model.IMediaContainer
+import us.nineworlds.serenity.common.rest.SerenityClient
+import us.nineworlds.serenity.common.rest.SerenityUser
+import us.nineworlds.serenity.common.rest.Types
+import us.nineworlds.serenity.jellyfin.BuildConfig
+import us.nineworlds.serenity.jellyfin.adapters.JellyfinMediaContainerAdaptor
+import us.nineworlds.serenity.jellyfin.moshi.LocalDateJsonAdapter
+import us.nineworlds.serenity.jellyfin.server.model.AuthenticateUserByName
+import us.nineworlds.serenity.jellyfin.server.model.AuthenticationResult
+import us.nineworlds.serenity.jellyfin.server.model.Item
+import us.nineworlds.serenity.jellyfin.server.model.PublicUserInfo
+import us.nineworlds.serenity.jellyfin.server.model.QueryFilters
+import us.nineworlds.serenity.jellyfin.server.model.QueryResult
+import java.io.File
+import java.util.UUID
+
+class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhost:8096") : SerenityClient {
+
+    private val usersService: JellyfinUsersService
+    private val filterService: JellyfinFilterService
+
+    var baseUrl: String
+    var accessToken: String? = null
+    lateinit var serverId: String
+    var userId: String? = null
+    var deviceId: String
+    var deviceName: String
+    val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+
+    init {
+        this.baseUrl = baseUrl
+        val logger = HttpLoggingInterceptor()
+        val cacheDir = File(context.cacheDir, "JellyfinClient")
+
+        val cacheSize = 10 * 1024 * 1024 // 10 MiB
+        val cache = Cache(cacheDir, cacheSize.toLong())
+
+        val okClient = RetrofitUrlManager.getInstance().with(OkHttpClient.Builder())
+        logger.level = HttpLoggingInterceptor.Level.BASIC
+        okClient.addInterceptor(logger)
+        okClient.cache(cache)
+
+        val moshi = Moshi.Builder()
+                .add(KotlinJsonAdapterFactory())
+                .add(LocalDateTime::class.java, LocalDateJsonAdapter()).build()
+
+        val builder = Retrofit.Builder()
+        val jellyfinRetrofit = builder.baseUrl(baseUrl)
+                .addConverterFactory(MoshiConverterFactory.create(moshi))
+                .client(okClient.build())
+                .build()
+
+        usersService = jellyfinRetrofit.create(JellyfinUsersService::class.java)
+        filterService = jellyfinRetrofit.create(JellyfinFilterService::class.java)
+
+
+        deviceId = pseudoUniqueID()
+        deviceName = "${Build.MANUFACTURER} ${Build.MODEL} "
+        Timber.d(this::class.java.simpleName, "Device Id: $deviceId")
+        Timber.d(this::class.java.simpleName, "Device Name : $deviceName")
+    }
+
+    fun fetchAllPublicUsers(): List<PublicUserInfo> {
+        val allPublicUsers = usersService.allPublicUsers()
+        return allPublicUsers.execute().body()!!
+    }
+
+    fun userImageUrl(userId: String): String {
+        return "$baseUrl/Users/$userId/Images/Primary"
+    }
+
+    fun authenticate(userName: String, password: String = ""): AuthenticationResult {
+        val authenticationResul = AuthenticateUserByName(userName, "", password, password)
+        val call = usersService.authenticate(authenticationResul, headerMap())
+        val response = call.execute()
+        if (response.isSuccessful) {
+            val body = response.body()
+            accessToken = body!!.accesToken
+            serverId = body.serverId
+            userId = body.userInfo.id!!
+
+            val prefEditor = prefs.edit()
+
+            prefEditor.putString("userId", userId)
+            prefEditor.putString("jellyfinAccessToken", accessToken)
+            prefEditor.apply()
+
+            return response.body()!!
+        }
+        throw IllegalStateException("error logging user in to Jellyfin Server")
+    }
+
+    fun currentUserViews(): QueryResult {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        val call = usersService.usersViews(headerMap(), userId!!)
+        return call.execute().body()!!
+    }
+
+    fun filters(itemId: String? = null, tags: List<String>? = null): QueryFilters {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        val call = filterService.availableFilters(headerMap(), userId!!)
+        return call.execute().body()!!
+    }
+
+    override fun fetchItemById(itemId: String): IMediaContainer {
+        try {
+            val result = fetchItem(itemId)
+            return when (result.type) {
+                "Series" -> JellyfinMediaContainerAdaptor().createSeriesList(listOf(result))
+                else -> JellyfinMediaContainerAdaptor().createVideoList(listOf(result))
+            }
+        } catch (ex: Exception) {
+            ex.printStackTrace()
+        }
+        return JellyfinMediaContainerAdaptor().createVideoList(emptyList())
+    }
+
+    fun fetchItem(id: String): Item {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        val call = usersService.fetchItem(headerMap(), userId!!, id)
+
+        return call.execute().body()!!
+    }
+
+    fun fetchItemQuery(id: String): QueryResult {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        val call = usersService.fetchItemQuery(headerMap(), userId!!, id, genre = null)
+
+        return call.execute().body()!!
+    }
+
+    private fun headerMap(): Map<String, String> {
+        val headers = HashMap<String, String>()
+        val authorizationValue =
+                "MediaBrowser Client=\"Jellyfin Client\", Device=\"$deviceName\", DeviceId=\"$deviceId\", Version=\"${BuildConfig.CLIENT_VERSION}.0\""
+        headers["X-Emby-Authorization"] = authorizationValue
+        if (accessToken != null) {
+            headers["Authorization"] = "Bearer $accessToken"
+        }
+        return headers
+    }
+
+    override fun userInfo(userId: String): SerenityUser {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun allAvailableUsers(): MutableList<SerenityUser> {
+        val allPublicUsers = fetchAllPublicUsers()
+        val allUsers = ArrayList<SerenityUser>()
+        for (user in allPublicUsers) {
+            val builder = us.nineworlds.serenity.common.rest.impl.SerenityUser.builder()
+            val sernityUser = builder.userName(user.name)
+                    .userId(user.id)
+                    .hasPassword(user.hasPassword)
+                    .build()
+            allUsers.add(sernityUser)
+        }
+        return allUsers
+    }
+
+    override fun authenticateUser(user: SerenityUser): SerenityUser {
+        val authenticatedUser = authenticate(user.userName)
+
+        return us.nineworlds.serenity.common.rest.impl.SerenityUser.builder()
+                .accessToken(authenticatedUser.accesToken)
+                .userName(user.userName)
+                .userId(user.userId)
+                .hasPassword(user.hasPassword())
+                .build()
+    }
+
+    override fun retrieveRootData(): IMediaContainer {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+
+        val call = usersService.usersViews(headerMap(), userId!!)
+
+        val queryResult = call.execute().body()
+
+        return JellyfinMediaContainerAdaptor().createMainMenu(queryResult!!.items)
+    }
+
+    override fun retrieveLibrary(): IMediaContainer {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    /**
+     *
+     */
+    override fun retrieveItemByCategories(): IMediaContainer {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        val call = usersService.usersViews(headerMap(), userId!!)
+
+        val queryResult = call.execute().body()
+
+        return JellyfinMediaContainerAdaptor().createMainMenu(queryResult!!.items)
+    }
+
+    override fun retrieveCategoriesById(key: String): IMediaContainer {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        val call = filterService.availableFilters(headerMap(), userId = userId!!, itemId = key)
+
+        val queryResult = call.execute().body()
+
+        return JellyfinMediaContainerAdaptor().createCategory(queryResult!!.genres!!)
+    }
+
+    override fun retrieveItemByIdCategory(key: String, category: String, types: Types): IMediaContainer {
+        return retrieveItemByIdCategory(key, category, types, 0, null)
+    }
+
+    override fun fetchSimilarItemById(itemId: String, types: Types): IMediaContainer {
+        val type = when (types) {
+            Types.MOVIES -> "Movie"
+            Types.SEASON -> "Season"
+            Types.SERIES -> "Series"
+            else -> "Episode"
+        }
+
+        val call = usersService.fetchSimilarItemById(headerMap(), itemId = itemId, userId = userId!!, includeItemType = "Movie")
+
+        val results = call.execute().body()
+        return JellyfinMediaContainerAdaptor().createVideoList(results!!.items)
+    }
+
+    override fun retrieveItemByIdCategory(key: String, category: String, types: Types, startIndex: Int, limit: Int?): IMediaContainer {
+        var isPlayed: Boolean? = null
+
+        val genre = when (category) {
+            "all", "unwatched" -> null
+            else -> category
+        }
+
+        val type = when (types) {
+            Types.MOVIES -> "Movie"
+            Types.SEASON -> "Season"
+            Types.SERIES -> "Series"
+            else -> "Episode"
+        }
+
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+
+        val call = when (category) {
+            "ondeck" -> {
+                if (type == "Season" || type == "Series") {
+                    usersService.resumableItems(headerMap(), userId = userId!!, parentId = key, includeItemType = "Episode")
+                } else {
+                    usersService.resumableItems(headerMap(), userId = userId!!, parentId = key, includeItemType = type)
+                }
+            }
+            "recentlyAdded" -> {
+                if (type == "Season" || type == "Series") {
+                    usersService.latestItems(headerMap(), userId = userId!!, parentId = key, includeItemType = "Episode")
+                } else {
+                    usersService.latestItems(headerMap(), userId = userId!!, parentId = key, includeItemType = type)
+                }
+            }
+            "unwatched" -> {
+                usersService.unwatchedItems(headerMap(), userId = userId!!, parentId = key, includeItemType = type)
+            }
+            else -> {
+                usersService.fetchItemQuery(
+                        headerMap(),
+                        userId = userId!!,
+                        parentId = key,
+                        genre = genre,
+                        isPlayed = isPlayed,
+                        includeItemType = type,
+                        startIndex = startIndex,
+                        limit = limit
+                )
+            }
+        }
+
+        val results = call.execute().body()
+        return JellyfinMediaContainerAdaptor().createVideoList(results!!.items)
+    }
+
+    override fun retrieveItemByCategories(key: String, category: String, secondaryCategory: String): IMediaContainer {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun retrieveSeasons(key: String): IMediaContainer {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        val call = usersService.fetchItemQuery(
+                headerMap(),
+                userId = userId!!,
+                parentId = key,
+                includeItemType = "Season",
+                genre = null
+        )
+
+        val results = call.execute().body()
+
+        return JellyfinMediaContainerAdaptor().createSeriesList(results!!.items)
+    }
+
+    override fun retrieveMusicMetaData(key: String): IMediaContainer {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun retrieveEpisodes(key: String): IMediaContainer {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        val call = usersService.fetchItemQuery(
+                headerMap(),
+                userId = userId!!,
+                parentId = key,
+                includeItemType = "Episode",
+                genre = null
+        )
+
+        val results = call.execute().body()
+
+        return JellyfinMediaContainerAdaptor().createVideoList(results!!.items)
+    }
+
+    override fun retrieveMovieMetaData(key: String): IMediaContainer {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun searchMovies(key: String, query: String): IMediaContainer {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        val call = usersService.search(headerMap(), userId!!, query)
+        val results = call.execute().body()
+        val itemIds = mutableListOf<String>()
+
+        for (searchHint in results!!.searchHints!!) {
+            itemIds.add(searchHint.id!!)
+        }
+
+        val itemCall = usersService.fetchItemQuery(
+                headerMap(),
+                userId = userId!!,
+                ids = itemIds.joinToString(separator = ","),
+                genre = null,
+                parentId = null
+        )
+
+        val itemResults = itemCall.execute().body()
+
+        return JellyfinMediaContainerAdaptor().createVideoList(itemResults!!.items)
+    }
+
+    override fun searchEpisodes(key: String, query: String): IMediaContainer? {
+        return null
+    }
+
+    override fun updateBaseUrl(baseUrl: String) {
+        this.baseUrl = baseUrl
+        RetrofitUrlManager.getInstance().setGlobalDomain(baseUrl)
+    }
+
+    override fun baseURL(): String = baseUrl
+
+    override fun watched(key: String): Boolean {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        val call = usersService.played(headerMap(), userId!!, key)
+
+        val result = call.execute()
+        return result.isSuccessful
+    }
+
+    override fun unwatched(key: String): Boolean {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        val call = usersService.unplayed(headerMap(), userId!!, key)
+
+        val result = call.execute()
+        return result.isSuccessful
+    }
+
+    override fun progress(key: String, offset: String): Boolean {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        var position = offset.toLong()
+
+        position = position.times(10000)
+
+        val call = usersService.progress(headerMap(), userId!!, key, null, position)
+        val result = call.execute()
+
+        return result.isSuccessful
+    }
+
+    override fun createMediaTagURL(resourceType: String, resourceName: String, identifier: String): String {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun createSectionsURL(key: String, category: String): String {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun createSectionsURL(): String {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun createSectionsUrl(key: String): String {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun createMovieMetadataURL(key: String): String {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun createEpisodesURL(key: String): String {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun createSeasonsURL(key: String): String {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun createImageURL(url: String, width: Int, height: Int): String {
+        return url
+    }
+
+    override fun createTranscodeUrl(id: String, offset: Int): String {
+        val playSessionId = UUID.randomUUID().toString()
+        var startOffset: Long = 0
+        if (offset > 0) {
+            startOffset = offset.toLong().times(10000)
+        }
+
+        return "${baseUrl}Videos/$id/stream.mkv?DeviceId=$deviceId&AudioCodec=aac&VideoCodec=h264&CopyTimeStamps=true&EnableAutoStreamCopy=true&StartTimeTicks=$startOffset&PlaySessionId=$playSessionId"
+    }
+
+    override fun reinitialize() {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun createUserImageUrl(user: SerenityUser, width: Int, height: Int): String {
+        return "$baseUrl/Users/${user.userId}/Images/Primary?Width=$width&Height=$height"
+    }
+
+    override fun startPlaying(itemId: String) {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+
+        val call = usersService.startPlaying(headerMap(), userId!!, itemId)
+
+        call.execute()
+    }
+
+    override fun stopPlaying(itemId: String, offset: Long) {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        val positionTicks = offset.times(10000)
+
+        val call = usersService.stopPlaying(headerMap(), userId!!, itemId, null, positionTicks.toString())
+        call.execute()
+    }
+
+    override fun retrieveSeriesById(key: String, categoryId: String): IMediaContainer {
+        var genre: String? = null
+        val isPlayed: Boolean? = null
+        val itemType = "Series"
+
+        genre = when (categoryId) {
+            "all", "unwatched" -> null
+            else -> categoryId
+        }
+
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+
+        val call = usersService.fetchItemQuery(
+                headerMap(),
+                userId = userId!!,
+                parentId = key,
+                genre = genre,
+                isPlayed = isPlayed,
+                includeItemType = itemType,
+                limitCount = 5
+        )
+
+        val results = call.execute().body()
+        return JellyfinMediaContainerAdaptor().createSeriesList(results!!.items)
+    }
+
+    override fun retrieveSeriesCategoryById(key: String): IMediaContainer {
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+        val call = filterService.availableFilters(headerMap(), userId!!, key)
+
+        val queryResult = call.execute().body()
+
+        return JellyfinMediaContainerAdaptor().createCategory(queryResult!!.genres!!, true)
+    }
+
+    fun fetchUserId() = prefs.getString("userId", "")
+
+    fun fetchAccessToken() = prefs.getString("jellyfinAccessToken", "")
+
+    override fun supportsMultipleUsers(): Boolean = true
+
+    private fun pseudoUniqueID(): String {
+        // If all else fails, if the user does have lower than API 9 (lower
+        // than Gingerbread), has reset their phone or 'Secure.ANDROID_ID'
+        // returns 'null', then simply the ID returned will be solely based
+        // off their Android device information. This is where the collisions
+        // can happen.
+        // Try not to use DISPLAY, HOST or ID - these items could change.
+        // If there are collisions, there will be overlapping data
+        var devIDShort = "35" + (Build.BOARD.length % 10) + (Build.BRAND.length % 10)
+
+        devIDShort += if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            (Build.SUPPORTED_ABIS[0].length % 10)
+        } else {
+            (Build.CPU_ABI.length % 10)
+        }
+
+        devIDShort +=
+            (Build.DEVICE.length % 10) + (Build.MANUFACTURER.length % 10) + (Build.MODEL.length
+                    % 10) + (Build.PRODUCT.length % 10)
+
+        // Only devices with API >= 9 have android.os.Build.SERIAL
+        // http://developer.android.com/reference/android/os/Build.html#SERIAL
+        // If a user upgrades software or roots their phone, there will be a duplicate entry
+        var serial: String
+        try {
+            serial = Build::class.java.getField("SERIAL")[null]?.toString() ?: ""
+
+            // Go ahead and return the serial for api => 9
+            return UUID(devIDShort.hashCode().toLong(), serial.hashCode().toLong()).toString()
+        } catch (e: java.lang.Exception) {
+            // String needs to be initialized
+            Timber.e(JellyfinAPIClient::class.java.simpleName, "getPseudoUniqueID: ", e)
+            serial = "ESYDV000" // some value
+        }
+
+        // Finally, combine the values we have found by using the UUID class to create a unique identifier
+        return UUID(devIDShort.hashCode().toLong(), serial.hashCode().toLong()).toString()
+    }
+
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClient.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClient.kt
@@ -10,6 +10,7 @@ import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.joda.time.LocalDateTime
+import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import timber.log.Timber
@@ -27,6 +28,7 @@ import us.nineworlds.serenity.jellyfin.server.model.PublicUserInfo
 import us.nineworlds.serenity.jellyfin.server.model.QueryFilters
 import us.nineworlds.serenity.jellyfin.server.model.QueryResult
 import java.io.File
+import java.io.IOException
 import java.util.UUID
 
 class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhost:8096") : SerenityClient {
@@ -77,7 +79,7 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
 
     fun fetchAllPublicUsers(): List<PublicUserInfo> {
         val allPublicUsers = usersService.allPublicUsers()
-        return allPublicUsers.execute().body()!!
+        return allPublicUsers.executeOrThrow()
     }
 
     fun userImageUrl(userId: String): String {
@@ -87,22 +89,19 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
     fun authenticate(userName: String, password: String = ""): AuthenticationResult {
         val authenticationResul = AuthenticateUserByName(userName, "", password, password)
         val call = usersService.authenticate(authenticationResul, headerMap())
-        val response = call.execute()
-        if (response.isSuccessful) {
-            val body = response.body()
-            accessToken = body!!.accesToken
-            serverId = body.serverId
-            userId = body.userInfo.id!!
+        val body = call.executeOrThrow()
 
-            val prefEditor = prefs.edit()
+        accessToken = body.accesToken
+        serverId = body.serverId
+        userId = body.userInfo.id!!
 
-            prefEditor.putString("userId", userId)
-            prefEditor.putString("jellyfinAccessToken", accessToken)
-            prefEditor.apply()
+        val prefEditor = prefs.edit()
 
-            return response.body()!!
-        }
-        throw IllegalStateException("error logging user in to Jellyfin Server")
+        prefEditor.putString("userId", userId)
+        prefEditor.putString("jellyfinAccessToken", accessToken)
+        prefEditor.apply()
+
+        return body
     }
 
     fun currentUserViews(): QueryResult {
@@ -110,7 +109,7 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
             userId = fetchUserId()
         }
         val call = usersService.usersViews(headerMap(), userId!!)
-        return call.execute().body()!!
+        return call.executeOrThrow()
     }
 
     fun filters(itemId: String? = null, tags: List<String>? = null): QueryFilters {
@@ -118,7 +117,7 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
             userId = fetchUserId()
         }
         val call = filterService.availableFilters(headerMap(), userId!!)
-        return call.execute().body()!!
+        return call.executeOrThrow()
     }
 
     override fun fetchItemById(itemId: String): IMediaContainer {
@@ -140,7 +139,7 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         }
         val call = usersService.fetchItem(headerMap(), userId!!, id)
 
-        return call.execute().body()!!
+        return call.executeOrThrow()
     }
 
     fun fetchItemQuery(id: String): QueryResult {
@@ -149,7 +148,7 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         }
         val call = usersService.fetchItemQuery(headerMap(), userId!!, id, genre = null)
 
-        return call.execute().body()!!
+        return call.executeOrThrow()
     }
 
     private fun headerMap(): Map<String, String> {
@@ -199,9 +198,9 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
 
         val call = usersService.usersViews(headerMap(), userId!!)
 
-        val queryResult = call.execute().body()
+        val queryResult = call.executeOrThrow()
 
-        return JellyfinMediaContainerAdaptor().createMainMenu(queryResult!!.items)
+        return JellyfinMediaContainerAdaptor().createMainMenu(queryResult.items)
     }
 
     override fun retrieveLibrary(): IMediaContainer {
@@ -217,9 +216,9 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         }
         val call = usersService.usersViews(headerMap(), userId!!)
 
-        val queryResult = call.execute().body()
+        val queryResult = call.executeOrThrow()
 
-        return JellyfinMediaContainerAdaptor().createMainMenu(queryResult!!.items)
+        return JellyfinMediaContainerAdaptor().createMainMenu(queryResult.items)
     }
 
     override fun retrieveCategoriesById(key: String): IMediaContainer {
@@ -228,9 +227,9 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         }
         val call = filterService.availableFilters(headerMap(), userId = userId!!, itemId = key)
 
-        val queryResult = call.execute().body()
+        val queryResult = call.executeOrThrow()
 
-        return JellyfinMediaContainerAdaptor().createCategory(queryResult!!.genres!!)
+        return JellyfinMediaContainerAdaptor().createCategory(queryResult.genres!!)
     }
 
     override fun retrieveItemByIdCategory(key: String, category: String, types: Types): IMediaContainer {
@@ -247,8 +246,8 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
 
         val call = usersService.fetchSimilarItemById(headerMap(), itemId = itemId, userId = userId!!, includeItemType = "Movie")
 
-        val results = call.execute().body()
-        return JellyfinMediaContainerAdaptor().createVideoList(results!!.items)
+        val results = call.executeOrThrow()
+        return JellyfinMediaContainerAdaptor().createVideoList(results.items)
     }
 
     override fun retrieveItemByIdCategory(key: String, category: String, types: Types, startIndex: Int, limit: Int?): IMediaContainer {
@@ -302,8 +301,8 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
             }
         }
 
-        val results = call.execute().body()
-        return JellyfinMediaContainerAdaptor().createVideoList(results!!.items)
+        val results = call.executeOrThrow()
+        return JellyfinMediaContainerAdaptor().createVideoList(results.items)
     }
 
     override fun retrieveItemByCategories(key: String, category: String, secondaryCategory: String): IMediaContainer {
@@ -322,9 +321,9 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
                 genre = null
         )
 
-        val results = call.execute().body()
+        val results = call.executeOrThrow()
 
-        return JellyfinMediaContainerAdaptor().createSeriesList(results!!.items)
+        return JellyfinMediaContainerAdaptor().createSeriesList(results.items)
     }
 
     override fun retrieveMusicMetaData(key: String): IMediaContainer {
@@ -343,9 +342,9 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
                 genre = null
         )
 
-        val results = call.execute().body()
+        val results = call.executeOrThrow()
 
-        return JellyfinMediaContainerAdaptor().createVideoList(results!!.items)
+        return JellyfinMediaContainerAdaptor().createVideoList(results.items)
     }
 
     override fun retrieveMovieMetaData(key: String): IMediaContainer {
@@ -357,10 +356,10 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
             userId = fetchUserId()
         }
         val call = usersService.search(headerMap(), userId!!, query)
-        val results = call.execute().body()
+        val results = call.executeOrThrow()
         val itemIds = mutableListOf<String>()
 
-        for (searchHint in results!!.searchHints!!) {
+        for (searchHint in results.searchHints!!) {
             itemIds.add(searchHint.id!!)
         }
 
@@ -372,9 +371,9 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
                 parentId = null
         )
 
-        val itemResults = itemCall.execute().body()
+        val itemResults = itemCall.executeOrThrow()
 
-        return JellyfinMediaContainerAdaptor().createVideoList(itemResults!!.items)
+        return JellyfinMediaContainerAdaptor().createVideoList(itemResults.items)
     }
 
     override fun searchEpisodes(key: String, query: String): IMediaContainer? {
@@ -449,7 +448,7 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
     override fun createSeasonsURL(key: String): String {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
-
+
     override fun createImageURL(url: String, width: Int, height: Int): String {
         return url
     }
@@ -516,8 +515,8 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
                 limitCount = 5
         )
 
-        val results = call.execute().body()
-        return JellyfinMediaContainerAdaptor().createSeriesList(results!!.items)
+        val results = call.executeOrThrow()
+        return JellyfinMediaContainerAdaptor().createSeriesList(results.items)
     }
 
     override fun retrieveSeriesCategoryById(key: String): IMediaContainer {
@@ -526,9 +525,9 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         }
         val call = filterService.availableFilters(headerMap(), userId!!, key)
 
-        val queryResult = call.execute().body()
+        val queryResult = call.executeOrThrow()
 
-        return JellyfinMediaContainerAdaptor().createCategory(queryResult!!.genres!!, true)
+        return JellyfinMediaContainerAdaptor().createCategory(queryResult.genres!!, true)
     }
 
     fun fetchUserId() = prefs.getString("userId", "")
@@ -574,6 +573,15 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
 
         // Finally, combine the values we have found by using the UUID class to create a unique identifier
         return UUID(devIDShort.hashCode().toLong(), serial.hashCode().toLong()).toString()
+    }
+
+    private fun <T> Call<T>.executeOrThrow(): T {
+        val response = execute()
+        if (response.isSuccessful) {
+            return response.body()
+                ?: throw IOException("Response from Jellyfin was null. Response Code: ${response.code()} - ${response.message()}")
+        }
+        throw IOException("Request to Jellyfin failed with code ${response.code()}, message: ${response.message()}")
     }
 
 }

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinFilterService.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinFilterService.kt
@@ -1,0 +1,18 @@
+package us.nineworlds.serenity.jellyfin.server.api
+
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.HeaderMap
+import retrofit2.http.Query
+import us.nineworlds.serenity.jellyfin.server.model.QueryFilters
+
+interface JellyfinFilterService {
+
+  @GET("/Genres?EnableUserData=false&SortBy=SortName&SortOrder=Ascending&EnableTotalRecordCount=false&EnableImages=false")
+  fun availableFilters(
+    @HeaderMap headerMap: Map<String, String>,
+    @Query("userId") userId: String,
+    @Query("ParentId") itemId: String? = null,
+    @Query("Recursive") recursive: Boolean = true
+  ): Call<QueryFilters>
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinUsersService.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinUsersService.kt
@@ -1,0 +1,157 @@
+package us.nineworlds.serenity.jellyfin.server.api
+
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.HeaderMap
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+import us.nineworlds.serenity.jellyfin.server.model.*
+
+interface JellyfinUsersService {
+
+  @GET("/Users/Public")
+  fun allPublicUsers(): Call<List<PublicUserInfo>>
+
+  @POST("/Users/AuthenticateByName")
+  fun authenticate(@Body authenticateUserByName: AuthenticateUserByName, @HeaderMap headerMap: Map<String, String>): Call<AuthenticationResult>
+
+  /**
+   * use this to provide menus.  You can ignore the Folders
+   * Folders will be identified by CollectionType: folders.  Movies are CollectionType: movies, TV Shows are CollectionType: tvshows
+   * 1. User must be logged in
+   * 2. Token must be valid
+   *
+   * The plex corresponding call is retrieveRootData()
+   */
+  @GET("/Users/{userId}/Views")
+  fun usersViews(@HeaderMap headerMap: Map<String, String>, @Path("userId") userId: String): Call<QueryResult>
+
+  @GET("/Users/{userId}/Items")
+  fun fetchItemQuery(
+    @HeaderMap headerMap: Map<String, String>,
+    @Path("userId") userId: String,
+    @Query("ParentId") parentId: String? = null,
+    @Query("Recursive") recursive: Boolean = true,
+    @Query("IncludeItemTypes") includeItemType: String? = null,
+    @Query("SortBy") sortOptions: String = "SortName",
+    @Query("SortOrder") sortOrder: String = "Ascending",
+    @Query("Genres") genre: String?,
+    @Query("IsPlayed") isPlayed: Boolean? = null,
+    @Query("LimitCount") limitCount: Int? = null,
+    @Query("Fields") fields: String = "Overview,MediaStreams,Studios,ParentId,Genres,MediaSources,SeasonCount,EpisodeCount,UserData,OfficialRating,CommunityRating,SeriesName,SeasonName,",
+    @Query("Ids") ids: String? = null,
+    @Query("StartIndex") startIndex: Int = 0,
+    @Query("Limit") limit: Int? = null
+  ): Call<QueryResult>
+
+  @GET("/Users/{userId}/Items")
+  fun resumableItems(
+    @HeaderMap headerMap: Map<String, String>,
+    @Path("userId") userId: String,
+    @Query("ParentId") parentId: String,
+    @Query("Recursive") recursive: Boolean = true,
+    @Query("SortBy") sortOptions: String = "DatePlayed",
+    @Query("SortOrder") sortOrder: String = "Descending",
+    @Query("Filters") filters: String = "IsResumable",
+    @Query("Fields") fields: String = "Overview,MediaStreams,Studios,ParentId,Genres,MediaSources,UserData,OfficialRating,CommunityRating",
+    @Query("IncludeItemTypes") includeItemType: String? = null,
+    ): Call<QueryResult>
+
+  @GET("/Users/{userId}/Items")
+  fun unwatchedItems(
+    @HeaderMap headerMap: Map<String, String>,
+    @Path("userId") userId: String,
+    @Query("ParentId") parentId: String,
+    @Query("Recursive") recursive: Boolean = true,
+    @Query("SortBy") sortOptions: String = "DatePlayed",
+    @Query("SortOrder") sortOrder: String = "Descending",
+    @Query("Filters") filters: String = "IsUnplayed",
+    @Query("Fields") fields: String = "Overview,MediaStreams,Studios,ParentId,Genres,MediaSources,UserData,OfficialRating,CommunityRating",
+    @Query("IncludeItemTypes") includeItemType: String? = null,
+  ): Call<QueryResult>
+
+  @GET("/Users/{userId}/Items?Limit=20")
+  fun latestItems(
+    @HeaderMap headerMap: Map<String, String>,
+    @Path("userId") userId: String,
+    @Query("ParentId") parentId: String,
+    @Query("Recursive") recursive: Boolean = true,
+    @Query("SortBy") sortOptions: String = "DateCreated",
+    @Query("SortOrder") sortOrder: String = "Descending",
+    @Query("IsPlayed") isPlayed: Boolean = false,
+    @Query("Filters") filters: String = "IsNotFolder,IsUnPlayed",
+    @Query("Fields") fields: String = "Overview,MediaStreams,Studios,ParentId,Genres,MediaSources,UserData,OfficialRating,CommunityRating",
+    @Query("IncludeItemTypes") includeItemType: String? = null,
+  ): Call<QueryResult>
+
+  @GET("/Users/{userId}/Items/{itemId}")
+  fun fetchItem(
+    @HeaderMap headerMap: Map<String, String>,
+    @Path("userId") userId: String,
+    @Path("itemId") itemId: String
+  ): Call<Item>
+
+  @POST("/Users/{userId}/PlayedItems/{itemId}")
+  fun played(
+    @HeaderMap headerMap: Map<String, String>,
+    @Path("userId") userId: String,
+    @Path("itemId") itemId: String
+  ): Call<UserItemData>
+
+  @DELETE("/Users/{userId}/PlayedItems/{itemId}")
+  fun unplayed(
+    @HeaderMap headerMap: Map<String, String>,
+    @Path("userId") userId: String,
+    @Path("itemId") itemId: String
+  ): Call<UserItemData>
+
+  @POST("/Users/{userId}/PlayingItems/{itemId}/Progress")
+  fun progress(
+    @HeaderMap headerMap: Map<String, String>,
+    @Path("userId") userId: String,
+    @Path("itemId") itemId: String,
+    @Query("MediaSourceId") mediaSourceId: String? = null,
+    @Query("PositionTicks") positionTicks: Long
+  ): Call<Void>
+
+  @POST("/Users/{userId}/PlayingItems/{itemId}")
+  fun startPlaying(
+    @HeaderMap headerMap: Map<String, String>,
+    @Path("userId") userId: String,
+    @Path("itemId") itemId: String,
+    @Query("MediaSourceId") mediaSourceId: String? = null
+  ): Call<Void>
+
+  @DELETE("/Users/{userId}/PlayingItems/{itemId}")
+  fun stopPlaying(
+    @HeaderMap headerMap: Map<String, String>,
+    @Path("userId") userId: String,
+    @Path("itemId") itemId: String,
+    @Query("MediaSourceId") mediaSourceId: String? = null,
+    @Query("PositionTicks") positionTicks: String
+  ): Call<Void>
+
+  @GET("/Search/Hints")
+  fun search(
+    @HeaderMap headerMap: Map<String, String>,
+    @Query("UserId") userId: String,
+    @Query("SearchTerm") searchTerm: String,
+    @Query("IsMovie") isMovie: Boolean = true,
+    @Query("IncludeItemTypes") includeItemTypes: String? = "Movie",
+    @Query("Limit") limit: Int? = 25
+  ): Call<Search>
+
+  @GET("/Movies/{itemId}/Similar")
+  fun fetchSimilarItemById(
+    @HeaderMap headerMap: Map<String, String>,
+    @Path("itemId") itemId: String,
+    @Query("UserId") userId: String,
+    @Query("IncludeItemTypes") includeItemType: String? = null,
+    @Query("Fields") fields: String = "Name,Id,Overview,MediaStreams,Studios,ParentId,Genres,MediaSources,SeasonCount,EpisodeCount,UserData,OfficialRating,CommunityRating,SeriesName,SeasonName",
+    @Query("Limit") limit: Int? = 25,
+  ): Call<QueryResult>
+
+}

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/model/filtermodel.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/model/filtermodel.kt
@@ -1,0 +1,13 @@
+package us.nineworlds.serenity.jellyfin.server.model
+
+import com.squareup.moshi.Json
+
+data class QueryFilters(
+  @Json(name = "Items") val genres: List<NameGuidPair>?,
+  @Json(name = "Tags") val tags: List<String>?
+)
+
+data class NameGuidPair(
+  @Json(name = "Name") val name: String,
+  @Json(name = "Id") val id: String
+)

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/model/itemsmodel.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/model/itemsmodel.kt
@@ -1,0 +1,104 @@
+package us.nineworlds.serenity.jellyfin.server.model
+
+import com.squareup.moshi.Json
+import org.joda.time.LocalDateTime
+
+data class QueryResult(
+  @Json(name = "Items") val items: List<Item>,
+  @Json(name = "TotalRecordCount") val totalRecordCount: Int
+)
+
+data class Item(
+  @Json(name = "Name") val name: String,
+  @Json(name = "ServerId") val serverId: String,
+  @Json(name = "Id") val id: String,
+  @Json(name = "Etag") val etag: String?,
+  @Json(name = "DateCreated") val dateCreated: LocalDateTime?,
+  @Json(name = "CollectionType") val collectionType: String?,
+  @Json(name = "Container") val container: String?,
+  @Json(name = "PremiereDate") val premiereDateTime: LocalDateTime?,
+  @Json(name = "Overview") val oveview: String?,
+  @Json(name = "ProductionYear") val productionYear: String?,
+  @Json(name = "OfficialRating") val officialRating: String?,
+  @Json(name = "ParentId") val parentId: String?,
+  @Json(name = "Rating") val rating: Double?,
+  @Json(name = "CommunityRating") val communityRating: Double?,
+  @Json(name = "RunTimeTicks") val runTimeTicks: Long?,
+  @Json(name = "UserData") val userData: UserData?,
+  @Json(name = "MediaStreams") val mediaStreams: List<MediaStream>?,
+  @Json(name = "MediaSources") val mediaSources: List<MediaSource>?,
+  @Json(name = "EpisodeCount") val episodeCount: Long?,
+  @Json(name = "IndexNumber") val episodeNumber: String?,
+  @Json(name = "Type") val type: String?,
+  @Json(name = "ParentLogoItemId") val parentLogoItemId: String?,
+  @Json(name = "SeriesId") val seriesId: String?,
+  @Json(name = "ParentIndexNumber") val parentIndexNumber: String?,
+  @Json(name = "SeasonName") val seasonName: String?,
+  @Json(name = "SeriesName") val seriesName: String?
+)
+
+data class UserData(
+  @Json(name = "PlaybackPositionTicks") val playbackPositionTicks: Long?,
+  @Json(name = "UnplayedItemCount") val unplayedItemCount: Long?,
+  @Json(name = "PlayCount") val playCount: Long?,
+  @Json(name = "IsFavorite") val isFavorite: Boolean?,
+  @Json(name = "Played") val played: Boolean?,
+  @Json(name = "Key") val key: String?,
+  @Json(name = "PlaybackPercentage") val playbackPercentage: Double?
+)
+
+data class MediaStream(
+  @Json(name = "Codec") val codec: String?,
+  @Json(name = "DisplayTitle") val displayTitle: String?,
+  @Json(name = "AspectRatio") val aspectRatio: String?,
+  @Json(name = "Type") val type: String?,
+  @Json(name = "ChannelType") val channelType: String?,
+  @Json(name = "Channels") val channels: String?
+)
+
+data class MediaSource(
+  @Json(name = "Id") val id: String?,
+  @Json(name = "Container") val container: String?,
+  @Json(name = "SupportsDirectStream") val directStream: Boolean?,
+  @Json(name = "SupportsTranscoding") val transcoding: Boolean?
+)
+
+data class UserItemData(
+  @Json(name = "Rating") val rating: Double?,
+  @Json(name = "PlayedPercentage") val playedPrecentage: Double?,
+  @Json(name = "UnplayedItemCount") val unplayedItemCount: Int?,
+  @Json(name = "PlaybackPositionTicks") val playbackPositionTicks: Long?,
+  @Json(name = "PlayCount") val playCount: Int?,
+  @Json(name = "IsFavorite") val isFavorite: Boolean?,
+  @Json(name = "Likes") val likes: Boolean?,
+  @Json(name = "LastPlayedDate") val lastPlayedDate: String?,
+  @Json(name = "Played") val played: Boolean?,
+  @Json(name = "Key") val key: String?,
+  @Json(name = "ItemId") val itemId: String?
+)
+
+data class Search(
+  @Json(name = "SearchHints") val searchHints: List<SearchHint>?,
+  @Json(name = "TotalRecordCount") val totalRecordCount: Int?
+)
+
+data class SearchHint(
+  @Json(name = "ItemId") val id: String?,
+  @Json(name = "Name") val name: String?,
+  @Json(name = "MatchedTerm") val matchedTerm: String?,
+  @Json(name = "IndexNumber") val indexNumber: Int?,
+  @Json(name = "ProductionYear") val productionYear: String?,
+  @Json(name = "PrimaryImageTag") val primaryImageTag: String?,
+  @Json(name = "ThumbImageTag") val thumbImageTag: String?,
+  @Json(name = "ThumbImageItemId") val thumbImageItemId: String?,
+  @Json(name = "BackdropImageTag") val backdropImageTag: String?,
+  @Json(name = "BackdropImageItemId") val backdropImageItemId: String?,
+  @Json(name = "IsFolder") val isFolder: Boolean?,
+  @Json(name = "RuntimeTicks") val runtimeTicks: Long?,
+  @Json(name = "MediaType") val mediatype: String?,
+  @Json(name = "StartDate") val startDate: LocalDateTime?,
+  @Json(name = "EndDate") val endDate: LocalDateTime?,
+  @Json(name = "Series") val series: String?,
+  @Json(name = "Status") val status: String?,
+  @Json(name = "Type") val type: String?
+)

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/model/usersmodel.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/model/usersmodel.kt
@@ -1,0 +1,28 @@
+package us.nineworlds.serenity.jellyfin.server.model
+
+import com.squareup.moshi.Json
+import org.joda.time.LocalDateTime
+
+data class PublicUserInfo(
+  @Json(name = "Name") val name: String?,
+  @Json(name = "ServerId") val serverId: String?,
+  @Json(name = "Id") val id: String?,
+  @Json(name = "HasPassword") val hasPassword: Boolean,
+  @Json(name = "HasConfiguredPassword") val hasConfiguredPassword: Boolean,
+  @Json(name = "HasConfiguredEasyPassword") val hasConfiguredEasyPassword: Boolean,
+  @Json(name = "LastLoginDate") val lastLoginDate: LocalDateTime?,
+  @Json(name = "LastActivityDate") val lastActivityDate: LocalDateTime?
+)
+
+data class AuthenticateUserByName(
+  @Json(name = "Username") val username: String,
+  @Json(name = "PassowrdMd5") val passwordMD5: String,
+  @Json(name = "Password") val password: String,
+  @Json(name = "Pw") val pw: String
+)
+
+data class AuthenticationResult(
+  @Json(name = "User") val userInfo: PublicUserInfo,
+  @Json(name = "AccessToken") val accesToken: String,
+  @Json(name = "ServerId") val serverId: String
+)

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/model/usersmodel.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/model/usersmodel.kt
@@ -16,7 +16,7 @@ data class PublicUserInfo(
 
 data class AuthenticateUserByName(
   @Json(name = "Username") val username: String,
-  @Json(name = "PassowrdMd5") val passwordMD5: String,
+  @Json(name = "PasswordMd5") val passwordMD5: String,
   @Json(name = "Password") val password: String,
   @Json(name = "Pw") val pw: String
 )

--- a/jellyfin-lib/src/test/kotlin/us/nineworlds/serenity/jellyfin/server/JellyfinServerDiscoverTest.kt
+++ b/jellyfin-lib/src/test/kotlin/us/nineworlds/serenity/jellyfin/server/JellyfinServerDiscoverTest.kt
@@ -3,6 +3,7 @@ package us.nineworlds.serenity.jellyfin.server
 import app.cash.turbine.turbineScope
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -45,6 +46,7 @@ class JellyfinServerDiscoverTest {
     @Test
     fun `discover any known servers`() = runTest {
         fakeServer.start()
+        fakeServer.awaitReady()
         turbineScope {
             val servers = ServerChannel.serverEvents.distinctUntilChanged().testIn(backgroundScope)
             serverDiscovery.findServers()
@@ -61,11 +63,13 @@ class JellyfinServerDiscoverTest {
 class FakeJellyfinServer {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var socket: DatagramSocket? = null
+    private val ready = CompletableDeferred<Unit>()
 
     fun start() {
         scope.launch {
             try {
                 socket = DatagramSocket(7359)
+                ready.complete(Unit)
                 while (isActive) {
                     val buf = ByteArray(256)
                     val packet = DatagramPacket(buf, buf.size)
@@ -97,6 +101,10 @@ class FakeJellyfinServer {
                 socket?.close()
             }
         }
+    }
+
+    suspend fun awaitReady() {
+        ready.await()
     }
 
     fun stop() {

--- a/jellyfin-lib/src/test/kotlin/us/nineworlds/serenity/jellyfin/server/JellyfinServerDiscoverTest.kt
+++ b/jellyfin-lib/src/test/kotlin/us/nineworlds/serenity/jellyfin/server/JellyfinServerDiscoverTest.kt
@@ -1,0 +1,106 @@
+package us.nineworlds.serenity.jellyfin.server
+
+import app.cash.turbine.turbineScope
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLog
+import timber.log.Timber
+import us.nineworlds.serenity.common.channels.ServerChannel
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.SocketException
+
+@RunWith(RobolectricTestRunner::class)
+class JellyfinServerDiscoverTest {
+
+    private lateinit var serverDiscovery : JellyfinServerDiscover
+    private lateinit var fakeServer: FakeJellyfinServer
+
+    @Before
+    fun setUp() {
+        Timber.plant(Timber.DebugTree())
+        ShadowLog.stream = System.out
+        serverDiscovery = JellyfinServerDiscover()
+        fakeServer = FakeJellyfinServer()
+    }
+
+    @After
+    fun tearDown() {
+        fakeServer.stop()
+    }
+
+    @Test
+    fun `discover any known servers`() = runTest {
+        fakeServer.start()
+        turbineScope {
+            val servers = ServerChannel.serverEvents.distinctUntilChanged().testIn(backgroundScope)
+            serverDiscovery.findServers()
+
+            val serverItem = servers.awaitItem()
+
+            assertThat(serverItem.serverName).isEqualTo("Jellyfin - Jellyfin Server")
+            servers.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+}
+
+class FakeJellyfinServer {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var socket: DatagramSocket? = null
+
+    fun start() {
+        scope.launch {
+            try {
+                socket = DatagramSocket(7359)
+                while (isActive) {
+                    val buf = ByteArray(256)
+                    val packet = DatagramPacket(buf, buf.size)
+                    socket?.receive(packet) ?: break
+
+                    val response = """
+                        {
+                           "Address": "http://127.0.0.1:8096",
+                           "Id": "someid",
+                           "Name": "Jellyfin Server"
+                        }
+                    """.trimIndent()
+
+                    val responsePacket = DatagramPacket(
+                        response.toByteArray(),
+                        response.length,
+                        packet.address,
+                        packet.port
+                    )
+                    socket?.send(responsePacket)
+                }
+            } catch (e: SocketException) {
+                Timber.d("FakeJellyfinServer socket closed, server stopping.")
+            } catch (e: Exception) {
+                if (isActive) {
+                    Timber.e(e, "FakeJellyfinServer error")
+                }
+            } finally {
+                socket?.close()
+            }
+        }
+    }
+
+    fun stop() {
+        socket?.close()
+        scope.cancel()
+    }
+}

--- a/jellyfin-lib/src/test/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClientTest.kt
+++ b/jellyfin-lib/src/test/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClientTest.kt
@@ -1,0 +1,112 @@
+package us.nineworlds.serenity.jellyfin.server.api
+
+import androidx.test.core.app.ApplicationProvider
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
+import us.nineworlds.serenity.common.rest.Types
+import us.nineworlds.serenity.jellyfin.server.model.AuthenticationResult
+
+@RunWith(RobolectricTestRunner::class)
+class JellyfinAPIClientTest {
+
+  private lateinit var client: JellyfinAPIClient
+
+  @Before
+  fun setUp() {
+    ShadowLog.stream = System.out
+
+    client = JellyfinAPIClient(context = ApplicationProvider.getApplicationContext())
+    client.updateBaseUrl("http://192.168.68.95:8096/emby/")
+  }
+
+  @Test
+  fun retrieveAllPublicUsers() {
+    val result = client.fetchAllPublicUsers()
+    assertThat(result).hasSize(2)
+  }
+
+  @Test fun loginAdminUser() {
+    val authenticateResult = authenticate()
+
+    assertThat(authenticateResult).isNotNull()
+    assertThat(authenticateResult.accesToken).isNotEmpty()
+    assertThat(client.serverId).isNotEmpty()
+    assertThat(client.accessToken).isNotNull()
+    assertThat(client.userId).isNotNull().isNotEmpty()
+  }
+
+  @Test fun testCurrentUsersViews() {
+    authenticate()
+
+    val result = client.currentUserViews()
+    assertThat(result.items).isNotEmpty()
+  }
+
+  @Test fun availableFiltersForCurrentUser() {
+    authenticate()
+
+    val currentViews = client.currentUserViews()
+    val id = currentViews.items[1].id
+    val result = client.filters(itemId = id)
+    assertThat(result).isNotNull()
+  }
+
+  @Test fun generateMainMenuForCurrentUser() {
+    authenticate()
+
+    val result = client.retrieveRootData()
+    assertThat(result).isNotNull()
+    assertThat(result.directories).isNotEmpty()
+  }
+
+  @Test fun createCategoriesForParentId() {
+    authenticate()
+
+    val result = client.retrieveItemByCategories()
+    val parentId = result.directories[1].key
+    val type = result.directories[1].type
+
+    val categories = client.retrieveCategoriesById(parentId)
+
+    assertThat(categories.directories).isNotEmpty()
+  }
+
+  @Test fun fetchAllMovies() {
+    authenticate()
+
+    val result = client.retrieveItemByCategories()
+    val parentId = result.directories[2].key
+
+    val movies = client.retrieveItemByIdCategory(parentId, "all", Types.EPISODE)
+
+    assertThat(movies.videos).isNotEmpty()
+  }
+
+  @Test fun fetchAllLatestMovies() {
+    authenticate()
+
+    val result = client.retrieveRootData()
+
+    val key = result.directories[0].key
+
+    val itemResult = client.retrieveItemByIdCategory(key, "recentlyAdded", Types.MOVIES)
+
+    assertThat(itemResult.videos).isNotEmpty()
+
+  }
+
+  private fun authenticate(): AuthenticationResult {
+    val users = client.fetchAllPublicUsers()
+    val user = users[0]
+
+    return client.authenticate(user.name!!, "")
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,5 +8,4 @@ pluginManagement {
 include ':serenity-app', ':emby-lib', ':serenity-common', ':serenity-android-common'
 include ':subtitle-converter'
 include ':manager'
-//include ':plexapp-rest-library'
-
+include ':jellyfin-lib'


### PR DESCRIPTION
Updates the code so that a jellyfin client can be potentially created. It includes the ability to handle service discovery and create the necessary
Jellyfin client.   The current implementation closely mirrors the Emby client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Jellyfin support: server discovery, remote browsing, item/series/episode retrieval, playback control, and user authentication.

* **Improvements**
  * Richer media mapping and metadata handling (streams, artwork, durations, offsets) and enhanced JSON date parsing.
  * Fixes to media stream handling to avoid data overwrite.

* **Tests**
  * Discovery and API client integration tests added.

* **Chores**
  * Version catalog and module inclusion updates; ignore recursive build directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->