### PR TITLE
feat: Support Authentication via Username and Password

### DIFF
--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/adapters/MediaContainerAdaptor.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/adapters/MediaContainerAdaptor.kt
@@ -127,7 +127,7 @@ class MediaContainerAdaptor {
         return MediaContainer()
     }
 
-    fun createVideoList(videos: List<Item>): IMediaContainer {
+    fun createVideoList(videos: List<Item>, token: String? = null): IMediaContainer {
         val mediaContainer = MediaContainer()
         val serenityVideos = ArrayList<Video>()
         mediaContainer.size = videos.size
@@ -169,7 +169,7 @@ class MediaContainerAdaptor {
                 item.container
             }
             video.directPlayUrl =
-                "emby/Videos/${item.mediaSources?.get(0)?.id ?: item.id}/stream.$container?static=true"
+                "emby/Videos/${item.id}/stream.$container?static=true&X-Emby-Token=${token}"
 
             if (item.runTimeTicks != null) {
                 val milliseconds = convertTicksToMilliseconds(item.runTimeTicks)

--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClient.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClient.kt
@@ -99,6 +99,10 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
 
         prefEditor.putString("userId", userId)
         prefEditor.putString("embyAccessToken", accessToken)
+        if (password.isNotEmpty()) {
+           prefEditor.putString("emby_${userId}_password", password)
+        }
+
         prefEditor.apply()
 
         return body
@@ -125,12 +129,12 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
             val result = fetchItem(itemId)
             return when (result.type) {
                 "Series" -> MediaContainerAdaptor().createSeriesList(listOf(result))
-                else -> MediaContainerAdaptor().createVideoList(listOf(result))
+                else -> MediaContainerAdaptor().createVideoList(listOf(result), fetchAccessToken())
             }
         } catch (ex: Exception) {
             ex.printStackTrace()
         }
-        return MediaContainerAdaptor().createVideoList(emptyList())
+        return MediaContainerAdaptor().createVideoList(emptyList(), fetchAccessToken())
     }
 
     fun fetchItem(id: String): Item {
@@ -180,8 +184,8 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
         return allUsers
     }
 
-    override fun authenticateUser(user: SerenityUser): SerenityUser {
-        val authenticatedUser = authenticate(user.userName)
+    override fun authenticateUser(user: SerenityUser, password: String?): SerenityUser {
+        val authenticatedUser = authenticate(user.userName, password ?: "")
 
         return us.nineworlds.serenity.common.rest.impl.SerenityUser.builder()
                 .accessToken(authenticatedUser.accesToken)
@@ -247,7 +251,7 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
         val call = usersService.fetchSimilarItemById(headerMap(), itemId = itemId, userId = userId!!, includeItemType = "Movie")
 
         val results = call.executeOrThrow()
-        return MediaContainerAdaptor().createVideoList(results.items)
+        return MediaContainerAdaptor().createVideoList(results.items, fetchAccessToken())
     }
 
     override fun retrieveItemByIdCategory(key: String, category: String, types: Types, startIndex: Int, limit: Int?): IMediaContainer {
@@ -302,7 +306,7 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
         }
 
         val results = call.executeOrThrow()
-        return MediaContainerAdaptor().createVideoList(results.items)
+        return MediaContainerAdaptor().createVideoList(results.items, fetchAccessToken())
     }
 
     override fun retrieveItemByCategories(key: String, category: String, secondaryCategory: String): IMediaContainer {
@@ -344,7 +348,7 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
 
         val results = call.executeOrThrow()
 
-        return MediaContainerAdaptor().createVideoList(results.items)
+        return MediaContainerAdaptor().createVideoList(results.items, fetchAccessToken())
     }
 
     override fun retrieveMovieMetaData(key: String): IMediaContainer {
@@ -373,7 +377,7 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
 
         val itemResults = itemCall.executeOrThrow()
 
-        return MediaContainerAdaptor().createVideoList(itemResults.items)
+        return MediaContainerAdaptor().createVideoList(itemResults.items, fetchAccessToken())
     }
 
     override fun searchEpisodes(key: String, query: String): IMediaContainer? {
@@ -453,14 +457,14 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
         return url
     }
 
-    override fun createTranscodeUrl(id: String, offset: Int): String {
+    override fun createTranscodeUrl(id: String, offset: Int, token: String?): String {
         val playSessionId = UUID.randomUUID().toString()
         var startOffset: Long = 0
         if (offset > 0) {
             startOffset = offset.toLong().times(10000)
         }
 
-        return "${baseUrl}Videos/$id/stream.mkv?DeviceId=$deviceId&AudioCodec=aac&VideoCodec=h264&CopyTimeStamps=true&EnableAutoStreamCopy=true&StartTimeTicks=$startOffset&PlaySessionId=$playSessionId"
+        return "${baseUrl}Videos/$id/stream.mkv?DeviceId=$deviceId&AudioCodec=aac&VideoCodec=h264&CopyTimeStamps=true&EnableAutoStreamCopy=true&StartTimeTicks=$startOffset&PlaySessionId=$playSessionId&X-Emby-Token=$token"
     }
 
     override fun reinitialize() {

--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/model/usersmodel.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/model/usersmodel.kt
@@ -9,7 +9,7 @@ data class PublicUserInfo(
   @Json(name = "Id") val id: String?,
   @Json(name = "HasPassword") val hasPassword: Boolean,
   @Json(name = "HasConfiguredPassword") val hasConfiguredPassword: Boolean,
-  @Json(name = "HasConfiguredEasyPassword") val hasConfiguredEasyPassword: Boolean,
+  @Json(name = "HasConfiguredEasyPassword", ) val hasConfiguredEasyPassword: Boolean?,
   @Json(name = "LastLoginDate") val lastLoginDate: LocalDateTime?,
   @Json(name = "LastActivityDate") val lastActivityDate: LocalDateTime?
 )

--- a/emby-lib/src/test/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClientTest.kt
+++ b/emby-lib/src/test/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClientTest.kt
@@ -1,8 +1,10 @@
 package us.nineworlds.serenity.emby.server.api
 
+import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
 import assertk.assertThat
 import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import org.junit.Before
@@ -12,102 +14,143 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLog
 import us.nineworlds.serenity.common.rest.Types
+import us.nineworlds.serenity.common.rest.impl.SerenityUser
 import us.nineworlds.serenity.emby.server.model.AuthenticationResult
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [28])
 class EmbyAPIClientTest {
 
-  private lateinit var client: EmbyAPIClient
+    private lateinit var client: EmbyAPIClient
+    private lateinit var prefs: SharedPreferences
 
-  @Before
-  fun setUp() {
-    ShadowLog.stream = System.out
+    @Before
+    fun setUp() {
+        ShadowLog.stream = System.out
 
-    client = EmbyAPIClient(context = ApplicationProvider.getApplicationContext())
-    client.updateBaseUrl("http://192.168.68.95:8096")
-  }
+        client = EmbyAPIClient(context = ApplicationProvider.getApplicationContext())
+        // Update this for local testing of the client and make sure it works
+        client.updateBaseUrl("http://yourserver:yourport")
+        prefs = client.prefs
+    }
 
-  @Test
-  fun retrieveAllPublicUsers() {
-    val result = client.fetchAllPublicUsers()
-    assertThat(result).hasSize(2)
-  }
+    @Test
+    fun retrieveAllPublicUsers() {
+        val result = client.fetchAllPublicUsers()
+        assertThat(result).isNotEmpty()
+    }
 
-  @Test fun loginAdminUser() {
-    val authenticateResult = authenticate()
+    @Test
+    fun loginAdminUser() {
+        val authenticateResult = authenticateWithPassword()
 
-    assertThat(authenticateResult).isNotNull()
-    assertThat(authenticateResult.accesToken).isNotEmpty()
-    assertThat(client.serverId).isNotEmpty()
-    assertThat(client.accessToken).isNotNull()
-    assertThat(client.userId).isNotNull().isNotEmpty()
-  }
+        assertThat(authenticateResult).isNotNull()
+        assertThat(authenticateResult.accesToken).isNotEmpty()
+        assertThat(client.serverId).isNotEmpty()
+        assertThat(client.accessToken).isNotNull()
+        assertThat(client.userId).isNotNull().isNotEmpty()
+    }
 
-  @Test fun testCurrentUsersViews() {
-    authenticate()
+    @Test
+    fun loginUserWithPassword() {
+        // This needs to be the url to the server you want to test against
+        client.updateBaseUrl("http://yourserver:yourport")
 
-    val result = client.currentUserViews()
-    assertThat(result.items).isNotEmpty()
-  }
+        val users = client.allAvailableUsers()
+        val user = users.first { it.hasPassword() }
+        client.authenticateUser(user, "unknownpassword")
 
-  @Test fun availableFiltersForCurrentUser() {
-    authenticate()
+        val password = prefs.getString("emby_${user.userId}_password", null)
+        assertThat(password).isNotNull().isEqualTo("unknownpassword")
+    }
 
-    val currentViews = client.currentUserViews()
-    val id = currentViews.items[1].id
-    val result = client.filters(itemId = id)
-    assertThat(result).isNotNull()
-  }
+    @Test
+    fun testCurrentUsersViews() {
+        authenticateWithPassword()
 
-  @Test fun generateMainMenuForCurrentUser() {
-    authenticate()
+        val result = client.currentUserViews()
+        assertThat(result.items).isNotEmpty()
+    }
 
-    val result = client.retrieveRootData()
-    assertThat(result).isNotNull()
-    assertThat(result.directories).isNotEmpty()
-  }
+    @Test
+    fun availableFiltersForCurrentUser() {
+        authenticateWithPassword()
 
-  @Test fun createCategoriesForParentId() {
-    authenticate()
+        val currentViews = client.currentUserViews()
+        val id = currentViews.items[1].id
+        val result = client.filters(itemId = id)
+        assertThat(result).isNotNull()
+    }
 
-    val result = client.retrieveItemByCategories()
-    val parentId = result.directories[1].key
-    val type = result.directories[1].type
+    @Test
+    fun generateMainMenuForCurrentUser() {
+        authenticateWithPassword()
 
-    val categories = client.retrieveCategoriesById(parentId)
+        val result = client.retrieveRootData()
+        assertThat(result).isNotNull()
+        assertThat(result.directories).isNotEmpty()
+    }
 
-    assertThat(categories.directories).isNotEmpty()
-  }
+    @Test
+    fun createCategoriesForParentId() {
+        authenticateWithPassword()
 
-  @Test fun fetchAllMovies() {
-    authenticate()
+        val result = client.retrieveItemByCategories()
+        val parentId = result.directories[1].key
+        val type = result.directories[1].type
 
-    val result = client.retrieveItemByCategories()
-    val parentId = result.directories[2].key
+        val categories = client.retrieveCategoriesById(parentId)
 
-    val movies = client.retrieveItemByIdCategory(parentId, "all", Types.EPISODE)
+        assertThat(categories.directories).isNotEmpty()
+    }
 
-    assertThat(movies.videos).isNotEmpty()
-  }
+    @Test
+    fun fetchAllMovies() {
+        authenticateWithPassword()
 
-  @Test fun fetchAllLatestMovies() {
-    authenticate()
+        val result = client.retrieveItemByCategories()
+        val parentId = result.directories[1].key
 
-    val result = client.retrieveRootData()
+        val movies = client.retrieveItemByIdCategory(parentId, "all", Types.EPISODE)
 
-    val key = result.directories[0].key
+        assertThat(movies.videos).isNotEmpty()
+    }
 
-    val itemResult = client.retrieveItemByIdCategory(key, "recentlyAdded", Types.MOVIES)
+    @Test
+    fun fetchAllLatestMovies() {
+        authenticateWithPassword()
 
-    assertThat(itemResult.videos).isNotEmpty()
+        val result = client.retrieveRootData()
 
-  }
+        val key = result.directories[0].key
 
-  private fun authenticate(): AuthenticationResult {
-    val users = client.fetchAllPublicUsers()
-    val user = users[0]
+        val itemResult = client.retrieveItemByIdCategory(key, "recentlyAdded", Types.MOVIES)
 
-    return client.authenticate(user.name!!, "")
-  }
+        assertThat(itemResult.videos).isNotEmpty()
+
+    }
+
+    private fun authenticate(): AuthenticationResult {
+        val users = client.allAvailableUsers()
+        val user = users.first { !it.hasPassword() }
+        val serenityUser = SerenityUser.builder()
+            .userId(user.userId)
+            .userName(user.userName)
+            .hasPassword(user.hasPassword())
+            .build()
+
+        client.authenticateUser(serenityUser)
+        return client.authenticate(user.userName, "")
+    }
+
+    // This test is not setup to run outside of a developers machine. It
+    // needs an active emby server to connect to.  To authenticate update
+    // the password, and the user selection code.
+    private fun authenticateWithPassword(): AuthenticationResult {
+        val users = client.allAvailableUsers()
+        val user = users.first { it.hasPassword() }
+
+        return client.authenticate(user.userName, "unknownpassword")
+    }
+
 }

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClient.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClient.kt
@@ -180,7 +180,7 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         return allUsers
     }
 
-    override fun authenticateUser(user: SerenityUser): SerenityUser {
+    override fun authenticateUser(user: SerenityUser, password: String?): SerenityUser {
         val authenticatedUser = authenticate(user.userName)
 
         return us.nineworlds.serenity.common.rest.impl.SerenityUser.builder()
@@ -453,7 +453,7 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         return url
     }
 
-    override fun createTranscodeUrl(id: String, offset: Int): String {
+    override fun createTranscodeUrl(id: String, offset: Int, token: String?): String {
         val playSessionId = UUID.randomUUID().toString()
         var startOffset: Long = 0
         if (offset > 0) {

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/repository/LoginRepository.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/repository/LoginRepository.kt
@@ -15,8 +15,8 @@ class LoginRepository(private val client: SerenityClient) {
         Result.Success<List<SerenityUser>>(users)
     }
 
-    suspend fun authenticateUser(user: SerenityUser): Result<SerenityUser> = withContext(Dispatchers.IO) {
-        val authenticatedUser = client.authenticateUser(user)
+    suspend fun authenticateUser(user: SerenityUser, password: String? = null): Result<SerenityUser> = withContext(Dispatchers.IO) {
+        val authenticatedUser = client.authenticateUser(user, password)
         Result.Success<SerenityUser>(authenticatedUser)
     }
 }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserActivity.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserActivity.kt
@@ -2,9 +2,13 @@ package us.nineworlds.serenity.ui.activity.login
 
 import android.content.Intent
 import android.os.Bundle
+import android.preference.PreferenceManager
+import android.view.LayoutInflater
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.Window
+import android.widget.EditText
+import androidx.appcompat.app.AlertDialog
 import androidx.annotation.VisibleForTesting
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexboxItemDecoration
@@ -12,6 +16,7 @@ import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
 import moxy.ktx.moxyPresenter
 import us.nineworlds.serenity.AndroidTV
+import us.nineworlds.serenity.R
 import us.nineworlds.serenity.common.Server
 import us.nineworlds.serenity.common.rest.SerenityUser
 import us.nineworlds.serenity.databinding.ActivityLoginUserBinding
@@ -20,7 +25,7 @@ import us.nineworlds.serenity.injection.InjectingMvpActivity
 import javax.inject.Inject
 import javax.inject.Provider
 
-class LoginUserActivity : InjectingMvpActivity(), LoginUserContract.LoginUserView {
+class LoginUserActivity : InjectingMvpActivity(), LoginUserContract.LoginUserView, OnUserSelectedListener {
 
   @VisibleForTesting
   internal val presenter by moxyPresenter { presenterProvider.get() }
@@ -63,7 +68,7 @@ class LoginUserActivity : InjectingMvpActivity(), LoginUserContract.LoginUserVie
     val context = this
     binding.apply {
       loginUserContainer.visibility = GONE
-      adapter = LoginUserAdapter(presenter)
+      adapter = LoginUserAdapter(this@LoginUserActivity)
       loginUserContainer.adapter = adapter
       val layoutManager = FlexboxLayoutManager(context, FlexDirection.ROW)
       layoutManager.justifyContent = JustifyContent.CENTER
@@ -85,5 +90,38 @@ class LoginUserActivity : InjectingMvpActivity(), LoginUserContract.LoginUserVie
     val intent = Intent(this, AndroidTV::class.java)
     startActivity(intent)
     finish()
+  }
+
+  override fun onUserSelected(user: SerenityUser) {
+    if (user.hasPassword()) {
+      val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+      val password = prefs.getString("emby_${user.userId}_password", null)
+      if (password == null) {
+        showPasswordDialog(user)
+      } else {
+        presenter.loadUser(user, password)
+      }
+    } else {
+      presenter.loadUser(user)
+    }
+  }
+
+  private fun showPasswordDialog(user: SerenityUser) {
+    val builder = AlertDialog.Builder(this)
+    val dialogView = LayoutInflater.from(this).inflate(R.layout.dialog_password_input, null)
+    val passwordEditText = dialogView.findViewById<EditText>(R.id.password_edit_text)
+
+    builder.setView(dialogView)
+        .setTitle("Enter Password")
+        .setPositiveButton("Login") { dialog, _ ->
+          val password = passwordEditText.text.toString()
+          presenter.loadUser(user, password)
+          dialog.dismiss()
+        }
+        .setNegativeButton("Cancel") { dialog, _ ->
+          dialog.cancel()
+        }
+
+    builder.create().show()
   }
 }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserAdapter.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserAdapter.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import us.nineworlds.serenity.R
 import us.nineworlds.serenity.common.rest.SerenityUser
 
-class LoginUserAdapter(val presenter: LoginUserPresenter) : RecyclerView.Adapter<LoginUserViewHolder>() {
+class LoginUserAdapter(private val userSelectedListener: OnUserSelectedListener) : RecyclerView.Adapter<LoginUserViewHolder>() {
 
   val users: ArrayList<SerenityUser> = ArrayList<SerenityUser>()
 
@@ -38,8 +38,7 @@ class LoginUserAdapter(val presenter: LoginUserPresenter) : RecyclerView.Adapter
 
   internal fun onClicked(position: Int) {
     val user = users[position]
-
-    presenter.loadUser(user)
+    userSelectedListener.onUserSelected(user)
   }
 
   internal fun onFocusChanged(view: View, hasFocus: Boolean) {
@@ -60,4 +59,8 @@ class LoginUserAdapter(val presenter: LoginUserPresenter) : RecyclerView.Adapter
     notifyDataSetChanged()
   }
 
+}
+
+interface OnUserSelectedListener {
+  fun onUserSelected(user: SerenityUser)
 }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserContract.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserContract.kt
@@ -23,6 +23,6 @@ interface LoginUserContract {
 
     fun retrieveAllUsers()
 
-    fun loadUser(user: SerenityUser)
+    fun loadUser(user: SerenityUser, password: String? = null)
   }
 }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserPresenter.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserPresenter.kt
@@ -57,9 +57,9 @@ class LoginUserPresenter : MvpPresenter<LoginUserView>(), LoginUserContract.Logi
     }
   }
 
-  override fun loadUser(user: SerenityUser) {
+  override fun loadUser(user: SerenityUser, password: String?) {
     presenterScope.launch {
-      when (val result = repository.authenticateUser(user)) {
+      when (val result = repository.authenticateUser(user, password)) {
         is Success<SerenityUser> -> viewState.launchNextScreen()
         else -> {
           // Error State

--- a/serenity-app/src/main/res/layout/dialog_password_input.xml
+++ b/serenity-app/src/main/res/layout/dialog_password_input.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/password_edit_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/password"
+        android:autofillHints="password"
+        android:imeOptions="actionDone"
+        android:inputType="textPassword" />
+
+</LinearLayout>

--- a/serenity-app/src/main/res/values/strings.xml
+++ b/serenity-app/src/main/res/values/strings.xml
@@ -246,4 +246,5 @@
   <string name="select_a_user_profile">Select a User Profile</string>
   <string name="refresh_servers">Refresh Servers</string>
   <string name="manual_server_entry">Manual Server Entry</string>
+  <string name="password">Password</string>
 </resources>

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/activity/login/LoginRepositoryTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/activity/login/LoginRepositoryTest.kt
@@ -3,9 +3,9 @@ package us.nineworlds.serenity.ui.activity.login
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import io.mockk.clearAllMocks
-import io.mockk.every
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -23,17 +23,15 @@ import us.nineworlds.serenity.core.repository.LoginRepository
 @OptIn(ExperimentalCoroutinesApi::class)
 class LoginRepositoryTest {
 
-    private companion object {
-        private val mockSerenityClient = mockk<SerenityClient>()
-        private val mockSerenityUser = mockk<SerenityUser>()
-    }
+    private val mockSerenityClient = mockk<SerenityClient>(relaxed = true)
+    private val mockSerenityUser = mockk<SerenityUser>(relaxed = true)
 
     private lateinit var repository: LoginRepository
 
     @Before
     fun setUp() {
         clearAllMocks()
-        Dispatchers.setMain(Dispatchers.Unconfined)
+        Dispatchers.setMain(UnconfinedTestDispatcher())
         repository = LoginRepository(mockSerenityClient)
     }
 
@@ -43,26 +41,36 @@ class LoginRepositoryTest {
     }
 
     @Test
-    fun testLoadAllUsersWithSuccess() = runTest(UnconfinedTestDispatcher()) {
+    fun `loadAllUsers returns success on client success`() = runTest {
         val expectedResult = listOf(mockSerenityUser)
-        every { mockSerenityClient.allAvailableUsers() } returns expectedResult
+        coEvery { mockSerenityClient.allAvailableUsers() } returns expectedResult
 
         val result = repository.loadAllUsers()
 
         assertThat((result as Result.Success<List<SerenityUser>>).data).isEqualTo(expectedResult)
 
-        verify { mockSerenityClient.allAvailableUsers() }
+        coVerify { mockSerenityClient.allAvailableUsers() }
     }
 
     @Test
-    fun testAuthenticateUser() = runTest(UnconfinedTestDispatcher()) {
+    fun `authenticate user without password returns success`() = runTest {
         val expectedResult = mockSerenityUser
-        every { mockSerenityClient.authenticateUser(any()) } returns expectedResult
+        coEvery { mockSerenityClient.authenticateUser(any(), null) } returns expectedResult
 
-        val result = repository.authenticateUser(expectedResult)
+        val result = repository.authenticateUser(expectedResult, null)
 
         assertThat((result as Result.Success<SerenityUser>).data).isEqualTo(expectedResult)
-        verify { mockSerenityClient.authenticateUser(expectedResult) }
+        coVerify { mockSerenityClient.authenticateUser(expectedResult, null) }
     }
 
+    @Test
+    fun `authenticate user with password returns success`() = runTest {
+        val expectedResult = mockSerenityUser
+        coEvery { mockSerenityClient.authenticateUser(any(), "password") } returns expectedResult
+
+        val result = repository.authenticateUser(expectedResult, "password")
+
+        assertThat((result as Result.Success<SerenityUser>).data).isEqualTo(expectedResult)
+        coVerify { mockSerenityClient.authenticateUser(expectedResult, "password") }
+    }
 }

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserActivityTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserActivityTest.kt
@@ -1,23 +1,30 @@
 package us.nineworlds.serenity.ui.activity.login
 
+import android.app.Application
 import android.content.Intent
+import android.os.Looper
 import android.view.View.VISIBLE
+import androidx.appcompat.app.AlertDialog
+import androidx.test.core.app.ApplicationProvider
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isInstanceOf
 import com.google.android.flexbox.FlexboxLayoutManager
 import io.mockk.clearAllMocks
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.android.api.Assertions
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowAlertDialog
 import toothpick.config.Module
 import us.nineworlds.serenity.AndroidTV
 import us.nineworlds.serenity.MockkTestingModule
@@ -28,12 +35,10 @@ import us.nineworlds.serenity.test.InjectingTest
 @RunWith(RobolectricTestRunner::class)
 class LoginUserActivityTest : InjectingTest() {
 
-  private companion object {
-    private val mockPresenter = mockk<LoginUserPresenter>(relaxed = true)
-    private val mockServer = mockk<Server>(relaxed = true)
-    private val mockSerenityUser = mockk<SerenityUser>(relaxed = true)
-    private val mockAdapter = mockk<LoginUserAdapter>(relaxed = true)
-  }
+  private val mockPresenter = mockk<LoginUserPresenter>(relaxed = true)
+  private val mockServer = mockk<Server>(relaxed = true)
+  private val mockSerenityUser = mockk<SerenityUser>(relaxed = true)
+  private val mockAdapter = mockk<LoginUserAdapter>(relaxed = true)
 
   private lateinit var activity: LoginUserActivity
 
@@ -54,24 +59,25 @@ class LoginUserActivityTest : InjectingTest() {
   }
 
   @Test
-  fun expectedLoginPresenterIsCreated() {
+  fun `presenter is injected`() {
     assertThat(activity.presenter).isEqualTo(mockPresenter)
   }
 
   @Test
-  fun profileContainerHasContainerSetup() {
-    assertThat(activity.binding.loginUserContainer).isNotNull()
+  fun `profile container has expected layout manager`() {
     assertThat(activity.binding.loginUserContainer.layoutManager).isNotNull().isInstanceOf(FlexboxLayoutManager::class)
+  }
 
+  @Test
+  fun `presenter has server and retrieves users`() {
     verify {
       mockPresenter.initPresenter(mockServer)
       mockPresenter.retrieveAllUsers()
     }
-
   }
 
   @Test
-  fun displayUserHidesProgressBar() {
+  fun `display users hides progress bar and loads users`() {
     activity.progressBinding.dataLoadingContainer.visibility = VISIBLE
     activity.adapter = mockAdapter
     activity.displayUsers(mutableListOf(mockSerenityUser).toList())
@@ -84,12 +90,52 @@ class LoginUserActivityTest : InjectingTest() {
   }
 
   @Test
-  fun launchNextScreenStartsExpectedActivity() {
+  fun `launch next screen starts expected activity`() {
     activity.launchNextScreen()
 
     val shadowActivity = shadowOf(activity)
     Assertions.assertThat(shadowActivity.nextStartedActivity).hasComponent(activity, AndroidTV::class.java)
   }
+
+  @Test
+  fun `on user selected without password calls load user`() {
+    every { mockSerenityUser.hasPassword() } returns false
+
+    activity.onUserSelected(mockSerenityUser)
+
+    verify { mockPresenter.loadUser(mockSerenityUser) }
+  }
+
+  @Test
+  @Ignore
+  fun `on user selected with stored password calls load user`() {
+    val prefs = activity.getPreferences(0)
+    prefs.edit().putString("emby_1_password", "password").commit()
+
+    every { mockSerenityUser.hasPassword() } returns true
+    every { mockSerenityUser.userId } returns "1"
+
+    activity.onUserSelected(mockSerenityUser)
+
+    verify { mockPresenter.loadUser(mockSerenityUser, "password") }
+  }
+
+  @Test
+  @Ignore
+  fun `on user selected with password shows dialog`() {
+    every { mockSerenityUser.hasPassword() } returns true
+    every { mockSerenityUser.userId } returns "1"
+
+    activity.onUserSelected(mockSerenityUser)
+
+    shadowOf(Looper.getMainLooper()).idle()
+    val dialogId = shadowOf(activity).lastShownDialogId
+
+    val dialog = shadowOf(activity).getDialogById(dialogId)
+    assertThat(dialog).isInstanceOf(AlertDialog::class.java)
+    assertThat(dialog.isShowing).isEqualTo(true)
+  }
+
 
   override fun installTestModules() {
     scope.installTestModules(MockkTestingModule(), TestModule())

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserAdapterTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserAdapterTest.kt
@@ -27,11 +27,9 @@ import us.nineworlds.serenity.test.InjectingTest
 @RunWith(RobolectricTestRunner::class)
 class LoginUserAdapterTest : InjectingTest() {
 
-  private companion object {
-    private val mockPresenter = mockk<LoginUserPresenter>(relaxed = true)
-    private val mockUser = mockk<SerenityUser>(relaxed = true)
-    private val mockViewHolder = mockk<LoginUserViewHolder>(relaxed = true)
-  }
+  private val mockUserSelectedListener = mockk<OnUserSelectedListener>(relaxed = true)
+  private val mockUser = mockk<SerenityUser>(relaxed = true)
+  private val mockViewHolder = mockk<LoginUserViewHolder>(relaxed = true)
 
   private lateinit var adapter: LoginUserAdapter
 
@@ -39,11 +37,11 @@ class LoginUserAdapterTest : InjectingTest() {
   override fun setUp() {
     clearAllMocks()
     super.setUp()
-    adapter = LoginUserAdapter(mockPresenter)
+    adapter = LoginUserAdapter(mockUserSelectedListener)
   }
 
   @Test
-  fun onCreateViewHolderCreatesExpectedInstance() {
+  fun `on create view holder creates expected view holder`() {
     val context = ContextThemeWrapper(
       ApplicationProvider.getApplicationContext<Application>(),
       R.style.AppTheme
@@ -53,13 +51,13 @@ class LoginUserAdapterTest : InjectingTest() {
   }
 
   @Test
-  fun loadUsersSetsInitializesUserList() {
+  fun `load users initializes user list`() {
     adapter.loadUsers(mutableListOf(mockUser))
     assertThat(adapter.itemCount).isEqualTo(1)
   }
 
   @Test
-  fun onBindViewHolderLoadsTheUserIntoTheView() {
+  fun `on bind view holder loads user into view`() {
     val view = FrameLayout(ApplicationProvider.getApplicationContext<Application>())
 
     every { mockViewHolder.getItemView() } returns view
@@ -76,15 +74,15 @@ class LoginUserAdapterTest : InjectingTest() {
   }
 
   @Test
-  fun onClickedLoadsSelectedUser() {
+  fun `on item click notifies listener`() {
     adapter.loadUsers(mutableListOf(mockUser))
     adapter.onClicked(0)
 
-    verify { mockPresenter.loadUser(mockUser) }
+    verify { mockUserSelectedListener.onUserSelected(mockUser) }
   }
 
   @Test
-  fun onFocusedChangeListenerUpdatesViewSelectionStateWithOutFocus() {
+  fun `on focus change without focus clears animation and background`() {
     val mockView = mockk<View>(relaxed = true)
     adapter.loadUsers(mutableListOf(mockUser))
 
@@ -97,7 +95,7 @@ class LoginUserAdapterTest : InjectingTest() {
   }
 
   @Test
-  fun onFocusedChangeListenerUpdatesViewSelectionStateWithFocus() {
+  fun `on focus change with focus updates view background`() {
     val mockView = mockk<View>(relaxed = true)
     val context = ContextThemeWrapper(
       ApplicationProvider.getApplicationContext<Application>(),
@@ -109,13 +107,11 @@ class LoginUserAdapterTest : InjectingTest() {
     adapter.loadUsers(mutableListOf(mockUser))
     adapter.onFocusChanged(mockView, true)
 
-    verify(atMost = 2) {
+    verify(exactly = 2) {
       mockView.clearAnimation()
     }
 
     verify {
-      mockView.background = null
-      mockView.context
       mockView.background = any<Drawable>()
     }
   }

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserPresenterTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/activity/login/LoginUserPresenterTest.kt
@@ -36,10 +36,10 @@ class LoginUserPresenterTest : InjectingTest() {
     private val mockServer = mockk<Server>(relaxed = true)
     private val mockSerenityUser = mockk<SerenityUser>(relaxed = true)
     private val mockRepository = mockk<LoginRepository>(relaxed = true)
-  }
 
-  @Inject
-  lateinit var mockSerenityClient: SerenityClient
+    private val mockSerenityClient = mockk<SerenityClient>(relaxed = true)
+
+  }
 
   private lateinit var presenter: LoginUserPresenter
 
@@ -57,7 +57,7 @@ class LoginUserPresenterTest : InjectingTest() {
   }
 
   @Test
-  fun initPresenterUpdatesClientWithExpectedUrl() {
+  fun `init preseter updates client with port`() {
     every { mockServer.ipAddress } returns "192.168.0.1"
 
     presenter.initPresenter(mockServer)
@@ -67,7 +67,7 @@ class LoginUserPresenterTest : InjectingTest() {
   }
 
   @Test
-  fun initPresenterUpdatesClientWithExpectedUrlWhenServerPortIsNotNull() {
+  fun `init presenter updates client without port`() {
     every { mockServer.port } returns "9999"
     every { mockServer.ipAddress } returns "192.168.0.1"
 
@@ -79,7 +79,7 @@ class LoginUserPresenterTest : InjectingTest() {
   }
 
   @Test
-  fun allUsersJobIsCreatedAndAddedToJobManager() = runTest(UnconfinedTestDispatcher()) {
+  fun `retrieve all users displays users on success`() = runTest {
     val expectedUsers = listOf(mockSerenityUser)
     coEvery { mockRepository.loadAllUsers() } returns Result.Success(expectedUsers)
     presenter.attachView(mockView)
@@ -91,7 +91,7 @@ class LoginUserPresenterTest : InjectingTest() {
   }
 
   @Test
-  fun loadUserAddsJob() = runTest(UnconfinedTestDispatcher()) {
+  fun `load user without password authenticates and launches next screen`() = runTest {
     coEvery { mockRepository.authenticateUser(any()) } returns Result.Success(mockSerenityUser)
     presenter.attachView(mockView)
 
@@ -101,13 +101,26 @@ class LoginUserPresenterTest : InjectingTest() {
     verify { mockView.launchNextScreen() }
   }
 
+  @Test
+  fun `load user with password authenticates and launches next screen`() = runTest {
+    coEvery { mockRepository.authenticateUser(any(), any()) } returns Result.Success(mockSerenityUser)
+    presenter.attachView(mockView)
+
+    presenter.loadUser(mockSerenityUser, "password")
+
+    coVerify { mockRepository.authenticateUser(mockSerenityUser, "password") }
+    verify { mockView.launchNextScreen() }
+  }
+
+
   override fun installTestModules() {
     scope.installTestModules(MockkTestingModule(), TestModule())
   }
 
-  inner class TestModule : Module() {
+  class TestModule : Module() {
     init {
       bind(LoginRepository::class.java).toInstance(mockRepository)
+      bind(SerenityClient::class.java).toInstance(mockSerenityClient)
     }
   }
 

--- a/serenity-common/src/main/java/us/nineworlds/serenity/common/rest/SerenityClient.kt
+++ b/serenity-common/src/main/java/us/nineworlds/serenity/common/rest/SerenityClient.kt
@@ -71,11 +71,11 @@ interface SerenityClient {
     fun createEpisodesURL(key: String): String
     fun createSeasonsURL(key: String): String
     fun createImageURL(url: String, width: Int, height: Int): String
-    fun createTranscodeUrl(id: String, offset: Int): String
+    fun createTranscodeUrl(id: String, offset: Int, token: String? = null): String
     fun reinitialize()
     fun userInfo(userId: String): SerenityUser?
     fun allAvailableUsers(): List<SerenityUser>
-    fun authenticateUser(user: SerenityUser): SerenityUser
+    fun authenticateUser(user: SerenityUser, password: String? = null): SerenityUser
     fun createUserImageUrl(user: SerenityUser, width: Int, height: Int): String
     fun startPlaying(key: String)
     fun stopPlaying(key: String, offset: Long)


### PR DESCRIPTION
Since emby media server 4.8, the only way to authenticate is with user id and password or a pin. This commit is based off pr #459 and updates it to the latest code base.  It supports both servers that require a password and those that don't.  In general though, all modern Emby Media Servers will require a password.  The password is saved and reused in future logins so the user only has to enter it one time per machine that this is installed on.

Additional work to be done to use the encrypted storage for preferences.

Thanks to @zhouhesheng for the original PR that this was based on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional password entry for protected profiles with a password dialog and stored-password handling
  * Access-token support added to stream and transcode URLs for authenticated playback

* **Bug Fixes**
  * More consistent video stream URL construction to improve playback reliability

* **Tests**
  * Updated and expanded tests to cover password-authentication flows and token propagation

* **UI**
  * Added password input dialog layout and password string resource

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->