### PR TITLE
feat: Migrate to Androidx.Media3 Exoplayer.

### DIFF
--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClient.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClient.kt
@@ -55,7 +55,7 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
         val cache = Cache(cacheDir, cacheSize.toLong())
 
         val okClient = RetrofitUrlManager.getInstance().with(OkHttpClient.Builder())
-        logger.level = HttpLoggingInterceptor.Level.BODY
+        logger.level = HttpLoggingInterceptor.Level.BASIC
         okClient.addInterceptor(logger)
         okClient.cache(cache)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ moshiKotlinVersion = "1.15.2"
 retrofitVersion = "2.9.0"
 jodaTimeVersion = "2.10.9.1"
 timberVersion = "5.0.1"
-exoplayerVersion = "2.19.1"
+media3Version = "1.9.0"
 simpleXmlVersion = "2.7.1"
 
 junitVersion = "4.13.2"
@@ -80,9 +80,9 @@ androidx-percentlayout = { module = "androidx.percentlayout:percentlayout", vers
 androidx-recycler-view = { module = "androidx.recyclerview:recyclerview", version.ref = "androidxRecyclerViewVersion"}
 commons-io = { module = "commons-io:commons-io", version.ref = "commonsIo" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commonsLang3Version" }
-exoplayer-core = { module = "com.google.android.exoplayer:exoplayer-core", version.ref = "exoplayerVersion"}
-exoplayer-ui = { module = "com.google.android.exoplayer:exoplayer-ui", version.ref = "exoplayerVersion"}
-exoplayer-okhttp = { module = "com.google.android.exoplayer:extension-okhttp", version.ref = "exoplayerVersion"}
+androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3Version" }
+androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3Version" }
+androidx-media3-datasource-okhttp = { module = "androidx.media3:media3-datasource-okhttp", version.ref = "media3Version" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBomVersion" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
@@ -147,4 +147,3 @@ androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-p
 ksp = { id = "com.google.devtools.ksp", version.ref = "kotlinKSPVersion" }
 android-application = { id = "com.android.application", version.ref = "agpVersion" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClient.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClient.kt
@@ -425,6 +425,14 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         return result.isSuccessful
     }
 
+    override fun progress(
+        key: String,
+        offset: String,
+        playSessionId: String?
+    ): Boolean {
+        TODO("Not yet implemented")
+    }
+
     override fun createMediaTagURL(resourceType: String, resourceName: String, identifier: String): String {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
@@ -475,7 +483,7 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         return "$baseUrl/Users/${user.userId}/Images/Primary?Width=$width&Height=$height"
     }
 
-    override fun startPlaying(itemId: String) {
+    override fun startPlaying(itemId: String): String? {
         if (userId == null) {
             userId = fetchUserId()
         }
@@ -483,6 +491,7 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         val call = usersService.startPlaying(headerMap(), userId!!, itemId)
 
         call.execute()
+        return UUID.randomUUID().toString()
     }
 
     override fun stopPlaying(itemId: String, offset: Long) {

--- a/serenity-app/build.gradle.kts
+++ b/serenity-app/build.gradle.kts
@@ -122,16 +122,9 @@ dependencies {
   implementation(libs.firebase.crashlytics)
 
   implementation(libs.github.glide.okhttp)
-  implementation(libs.exoplayer.core) {
-    exclude(module = "support-annotations")
-  }
-  implementation(libs.exoplayer.ui) {
-    exclude(module = "support-annotations")
-  }
-
-  implementation(libs.exoplayer.okhttp) {
-    exclude(module = "support-annotations")
-  }
+  implementation(libs.androidx.media3.exoplayer)
+  implementation(libs.androidx.media3.ui)
+  implementation(libs.androidx.media3.datasource.okhttp)
 
   implementation(libs.okhttp) {
     exclude(group = "com.android.support")

--- a/serenity-app/src/main/java/us/nineworlds/serenity/SerenityApplication.kt
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/SerenityApplication.kt
@@ -32,9 +32,10 @@ import android.preference.PreferenceManager
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
-import com.google.android.exoplayer2.database.ExoDatabaseProvider
-import com.google.android.exoplayer2.upstream.cache.LeastRecentlyUsedCacheEvictor
-import com.google.android.exoplayer2.upstream.cache.SimpleCache
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.database.ExoDatabaseProvider
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.SimpleCache
 import com.google.firebase.analytics.FirebaseAnalytics
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -99,6 +100,7 @@ open class SerenityApplication : Application() {
         Toothpick.inject(this, scope)
     }
 
+    @UnstableApi
     override fun onCreate() {
         super.onCreate()
         init()
@@ -106,7 +108,8 @@ open class SerenityApplication : Application() {
         discoverServers()
         MediaCodecInfoUtil.logAvailableCodecs()
 
-        val leastRecentlyUsedCacheEvictor = LeastRecentlyUsedCacheEvictor((200 * 1024 * 1024).toLong())
+        val leastRecentlyUsedCacheEvictor =
+            LeastRecentlyUsedCacheEvictor((200 * 1024 * 1024).toLong())
         val exoDatabaseProvider = ExoDatabaseProvider(this)
         simpleCache = SimpleCache(cacheDir, leastRecentlyUsedCacheEvictor, exoDatabaseProvider)
     }

--- a/serenity-app/src/main/java/us/nineworlds/serenity/core/util/AndroidHelper.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/core/util/AndroidHelper.java
@@ -27,8 +27,15 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 
-import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.audio.AudioCapabilities;
+import androidx.annotation.OptIn;
+import androidx.media3.common.C;
+import androidx.media3.common.MimeTypes;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.audio.AudioCapabilities;
+import androidx.media3.exoplayer.mediacodec.MediaCodecInfo;
+import androidx.media3.exoplayer.mediacodec.MediaCodecUtil;
+
+import java.util.List;
 
 public class AndroidHelper {
 
@@ -65,12 +72,38 @@ public class AndroidHelper {
     return Build.MODEL.toLowerCase().contains(ANDROID_BRAVIA_MODEL.toLowerCase());
   }
 
-  public boolean enableTunneling() {
-    return false;
-  }
+    /**
+     * Checks if the device supports tunneling for common video formats (HEVC or AVC).
+     * @return true if tunneling is supported for either H.265 or H.264.
+     */
+    @OptIn(markerClass = UnstableApi.class)
+    public boolean enableTunneling() {
+        // Tunneling is practically only useful/stable on API 24+ (Android 7.0)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            return false;
+        }
+        return isTunnelingSupported(MimeTypes.VIDEO_H265)
+                || isTunnelingSupported(MimeTypes.VIDEO_H264);
+    }
 
-  public boolean isBeyondTV() {
-    return Build.MODEL.toLowerCase().contains(ANDROID_TCL_BEYONDTV5.toLowerCase()) || Build.MODEL.toLowerCase().contains("smart tv");
+
+    @OptIn(markerClass = UnstableApi.class)
+  public boolean isTunnelingSupported(String mimeType) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+      return false;
+    }
+
+    try {
+      List<MediaCodecInfo> decoderInfos = MediaCodecUtil.getDecoderInfos(mimeType, false, false);
+      for (MediaCodecInfo info : decoderInfos) {
+        if (info.capabilities != null && info.capabilities.isFeatureSupported(android.media.MediaCodecInfo.CodecCapabilities.FEATURE_TunneledPlayback)) {
+          return true;
+        }
+      }
+    } catch (Exception e) {
+      return false;
+    }
+    return false;
   }
 
   public boolean isLeanbackSupported() {
@@ -78,7 +111,8 @@ public class AndroidHelper {
     return pm.hasSystemFeature(ANDROID_SOFTWARE_LEANBACK);
   }
 
-  public boolean isAudioPassthroughSupported(String codec) {
+    @OptIn(markerClass = UnstableApi.class)
+    public boolean isAudioPassthroughSupported(String codec) {
     AudioCapabilities audioCapabilities = AudioCapabilities.getCapabilities(context);
     int encoding = 0;
     switch (codec.toLowerCase()) {

--- a/serenity-app/src/main/java/us/nineworlds/serenity/injection/modules/ExoplayerVideoModule.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/injection/modules/ExoplayerVideoModule.java
@@ -1,8 +1,11 @@
 package us.nineworlds.serenity.injection.modules;
 
-import com.google.android.exoplayer2.trackselection.TrackSelector;
-import com.google.android.exoplayer2.upstream.DataSource;
-import com.google.android.exoplayer2.upstream.HttpDataSource;
+
+import androidx.annotation.OptIn;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.datasource.DataSource;
+import androidx.media3.datasource.HttpDataSource;
+import androidx.media3.exoplayer.trackselection.TrackSelector;
 
 import toothpick.config.Module;
 import us.nineworlds.serenity.injection.modules.providers.DataSourceFactoryProvider;
@@ -14,7 +17,8 @@ import us.nineworlds.serenity.ui.video.player.ExoplayerPresenter;
 
 public class ExoplayerVideoModule extends Module {
 
-  public ExoplayerVideoModule() {
+    @OptIn(markerClass = UnstableApi.class)
+    public ExoplayerVideoModule() {
     super();
 
 

--- a/serenity-app/src/main/java/us/nineworlds/serenity/injection/modules/providers/DataSourceFactoryProvider.kt
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/injection/modules/providers/DataSourceFactoryProvider.kt
@@ -1,11 +1,13 @@
 package us.nineworlds.serenity.injection.modules.providers
 
 import android.content.Context
-import com.google.android.exoplayer2.upstream.DataSource
-import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter
-import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory
-import com.google.android.exoplayer2.upstream.HttpDataSource
-import com.google.android.exoplayer2.upstream.cache.CacheDataSource
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultDataSourceFactory
+import androidx.media3.datasource.HttpDataSource
+import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import us.nineworlds.serenity.SerenityApplication
 import us.nineworlds.serenity.common.android.injection.ApplicationContext
 import javax.inject.Inject
@@ -18,9 +20,12 @@ class DataSourceFactoryProvider : Provider<DataSource.Factory> {
 
     @Inject
     lateinit var httpDataSourceFactory: HttpDataSource.Factory
+
+    @OptIn(UnstableApi::class)
     override fun get(): DataSource.Factory {
         val bandwidthMeter = DefaultBandwidthMeter.getSingletonInstance(context)
-        val defaultDataSourceFactory = DefaultDataSourceFactory(context, bandwidthMeter, httpDataSourceFactory)
+        val defaultDataSourceFactory =
+            DefaultDataSourceFactory(context, bandwidthMeter, httpDataSourceFactory)
         return CacheDataSource.Factory()
                 .setCache(SerenityApplication.simpleCache)
                 .setUpstreamDataSourceFactory(defaultDataSourceFactory)

--- a/serenity-app/src/main/java/us/nineworlds/serenity/injection/modules/providers/DefaultMappingTrackSelectorProvider.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/injection/modules/providers/DefaultMappingTrackSelectorProvider.java
@@ -2,9 +2,11 @@ package us.nineworlds.serenity.injection.modules.providers;
 
 import android.content.Context;
 
-import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
+
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.trackselection.AdaptiveTrackSelection;
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector;
+import androidx.media3.exoplayer.trackselection.MappingTrackSelector;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -17,7 +19,8 @@ public class DefaultMappingTrackSelectorProvider implements Provider<MappingTrac
   @ApplicationContext
   Context context;
 
-  @Override public MappingTrackSelector get() {
+    @UnstableApi
+    @Override public MappingTrackSelector get() {
     return new DefaultTrackSelector(context, new AdaptiveTrackSelection.Factory());
   }
 }

--- a/serenity-app/src/main/java/us/nineworlds/serenity/injection/modules/providers/EventLoggerProvider.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/injection/modules/providers/EventLoggerProvider.java
@@ -1,15 +1,19 @@
 package us.nineworlds.serenity.injection.modules.providers;
 
-import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
+
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.trackselection.MappingTrackSelector;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 
 import us.nineworlds.serenity.ui.video.player.EventLogger;
 
+@UnstableApi
 public class EventLoggerProvider implements Provider<EventLogger> {
 
-  @Inject MappingTrackSelector mappingTrackSelector;
+  @Inject
+  MappingTrackSelector mappingTrackSelector;
 
   @Override public EventLogger get() {
     return new EventLogger(mappingTrackSelector);

--- a/serenity-app/src/main/java/us/nineworlds/serenity/injection/modules/providers/HttpDataSourceFactoryProvider.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/injection/modules/providers/HttpDataSourceFactoryProvider.java
@@ -1,7 +1,8 @@
 package us.nineworlds.serenity.injection.modules.providers;
 
-import com.google.android.exoplayer2.ext.okhttp.OkHttpDataSourceFactory;
-import com.google.android.exoplayer2.upstream.HttpDataSource;
+
+import androidx.media3.datasource.HttpDataSource;
+import androidx.media3.datasource.okhttp.OkHttpDataSource;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -15,6 +16,6 @@ public class HttpDataSourceFactoryProvider implements Provider<HttpDataSource.Fa
   @Inject OkHttpClient okHttpClient;
 
   @Override public HttpDataSource.Factory get() {
-    return new OkHttpDataSourceFactory(okHttpClient, userAgent, null, null);
+    return new OkHttpDataSource.Factory(okHttpClient).setUserAgent(userAgent);
   }
 }

--- a/serenity-app/src/main/java/us/nineworlds/serenity/ui/video/player/EventLogger.java
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/ui/video/player/EventLogger.java
@@ -18,24 +18,27 @@ package us.nineworlds.serenity.ui.video.player;
 import android.os.SystemClock;
 import android.util.Log;
 
-import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.Format;
-import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.audio.AudioRendererEventListener;
-import com.google.android.exoplayer2.decoder.DecoderCounters;
-import com.google.android.exoplayer2.metadata.Metadata;
-import com.google.android.exoplayer2.metadata.MetadataOutput;
-import com.google.android.exoplayer2.metadata.emsg.EventMessage;
-import com.google.android.exoplayer2.metadata.id3.ApicFrame;
-import com.google.android.exoplayer2.metadata.id3.CommentFrame;
-import com.google.android.exoplayer2.metadata.id3.GeobFrame;
-import com.google.android.exoplayer2.metadata.id3.Id3Frame;
-import com.google.android.exoplayer2.metadata.id3.PrivFrame;
-import com.google.android.exoplayer2.metadata.id3.TextInformationFrame;
-import com.google.android.exoplayer2.metadata.id3.UrlLinkFrame;
-import com.google.android.exoplayer2.source.MediaSourceEventListener;
-import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
-import com.google.android.exoplayer2.video.VideoRendererEventListener;
+import androidx.annotation.Nullable;
+import androidx.media3.common.C;
+import androidx.media3.common.Format;
+import androidx.media3.common.Player;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.audio.AudioRendererEventListener;
+import androidx.media3.exoplayer.DecoderCounters;
+import androidx.media3.exoplayer.DecoderReuseEvaluation;
+import androidx.media3.common.Metadata;
+import androidx.media3.exoplayer.metadata.MetadataOutput;
+import androidx.media3.extractor.metadata.emsg.EventMessage;
+import androidx.media3.extractor.metadata.id3.ApicFrame;
+import androidx.media3.extractor.metadata.id3.CommentFrame;
+import androidx.media3.extractor.metadata.id3.GeobFrame;
+import androidx.media3.extractor.metadata.id3.Id3Frame;
+import androidx.media3.extractor.metadata.id3.PrivFrame;
+import androidx.media3.extractor.metadata.id3.TextInformationFrame;
+import androidx.media3.extractor.metadata.id3.UrlLinkFrame;
+import androidx.media3.exoplayer.source.MediaSourceEventListener;
+import androidx.media3.exoplayer.trackselection.MappingTrackSelector;
+import androidx.media3.exoplayer.video.VideoRendererEventListener;
 
 import java.text.NumberFormat;
 import java.util.Locale;
@@ -49,6 +52,7 @@ import us.nineworlds.serenity.core.logger.Logger;
 /**
  * Logs player events using {@link Log}.
  */
+@UnstableApi
 public final class EventLogger implements AudioRendererEventListener, VideoRendererEventListener,
         MediaSourceEventListener, MetadataOutput {
 
@@ -93,7 +97,7 @@ public final class EventLogger implements AudioRendererEventListener, VideoRende
     logger.debug("audioDecoderInitialized [" + getSessionTimeString() + ", " + decoderName + "]");
   }
 
-  @Override public void onAudioInputFormatChanged(Format format) {
+  @Override public void onAudioInputFormatChanged(Format format, @Nullable DecoderReuseEvaluation decoderReuseEvaluation) {
     logger.debug("audioFormatChanged [" + getSessionTimeString() + ", " + Format.toLogString(format) + "]");
   }
 
@@ -112,7 +116,7 @@ public final class EventLogger implements AudioRendererEventListener, VideoRende
     logger.debug("videoDecoderInitialized [" + getSessionTimeString() + ", " + decoderName + "]");
   }
 
-  @Override public void onVideoInputFormatChanged(Format format) {
+  @Override public void onVideoInputFormatChanged(Format format, @Nullable DecoderReuseEvaluation decoderReuseEvaluation) {
     logger.debug("videoFormatChanged [" + getSessionTimeString() + ", " + Format.toLogString(format) + "]");
   }
 

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerPresenter.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerPresenter.kt
@@ -1,8 +1,8 @@
 package us.nineworlds.serenity.ui.video.player
 
 import android.view.View
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.ui.PlayerControlView
+import androidx.media3.common.Player
+import androidx.media3.ui.PlayerControlView
 import kotlinx.coroutines.launch
 import moxy.InjectViewState
 import moxy.MvpPresenter
@@ -75,11 +75,11 @@ class ExoplayerPresenter : MvpPresenter<ExoplayerView>(), ExoplayerPresenter,
     }
   }
 
-  override fun onPositionDiscontinuity(reason: Int) = Unit
+  override fun onPositionDiscontinuity(oldPosition: Player.PositionInfo, newPosition: Player.PositionInfo, reason: Int) = Unit
 
   override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) = Unit
 
-  override fun onPlayerStateChanged(playWhenReady: Boolean, playbackState: Int) {
+  override fun onPlaybackStateChanged(playbackState: Int) {
     if (Player.STATE_ENDED == playbackState) {
       stopPlaying(video.resumeOffset.toLong())
       viewState.playbackEnded()
@@ -88,7 +88,7 @@ class ExoplayerPresenter : MvpPresenter<ExoplayerView>(), ExoplayerPresenter,
     }
   }
 
-  override fun onLoadingChanged(isLoading: Boolean) = Unit
+  override fun onIsLoadingChanged(isLoading: Boolean) = Unit
 
   override fun onRepeatModeChanged(repeatMode: Int) = Unit
 

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerVideoActivity.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerVideoActivity.kt
@@ -12,18 +12,22 @@ import android.os.Looper
 import android.view.KeyEvent
 import android.view.View
 import android.widget.FrameLayout
-import com.google.android.exoplayer2.DefaultLoadControl
-import com.google.android.exoplayer2.DefaultRenderersFactory
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory
-import com.google.android.exoplayer2.source.MediaSource
-import com.google.android.exoplayer2.source.ProgressiveMediaSource
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
-import com.google.android.exoplayer2.trackselection.TrackSelector
-import com.google.android.exoplayer2.ui.PlayerView
-import com.google.android.exoplayer2.upstream.DataSource
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import androidx.media3.exoplayer.trackselection.TrackSelector
+import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.ui.PlayerView
 import moxy.presenter.InjectPresenter
 import moxy.presenter.ProvidePresenter
 import timber.log.Timber
@@ -43,6 +47,7 @@ import us.nineworlds.serenity.ui.util.DisplayUtils.overscanCompensation
 import javax.inject.Inject
 import javax.inject.Provider
 
+@UnstableApi
 @OpenForTesting
 class ExoplayerVideoActivity : SerenityActivity(), ExoplayerContract.ExoplayerView {
 
@@ -191,13 +196,21 @@ class ExoplayerVideoActivity : SerenityActivity(), ExoplayerContract.ExoplayerVi
 
     internal fun createSimpleExoplayer(): ExoPlayer {
         if (trackSelector is DefaultTrackSelector) {
+
             val tunnelingEnabled = androidHelper.enableTunneling()
+
             Timber.d("Tunneling enabled: %s", tunnelingEnabled)
-            val parameters = DefaultTrackSelector.ParametersBuilder(this)
+            val audioOffloadPreferences = TrackSelectionParameters.AudioOffloadPreferences.Builder()
+                .setAudioOffloadMode(TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED)
+                .setIsSpeedChangeSupportRequired(false)
+                .setIsGaplessSupportRequired(false)
+                .build()
+            val parameters = DefaultTrackSelector.Parameters.Builder()
                     .setTunnelingEnabled(tunnelingEnabled)
                     .setAllowAudioMixedDecoderSupportAdaptiveness(true)
                     .setExceedAudioConstraintsIfNecessary(false)
                     .setAllowAudioMixedSampleRateAdaptiveness(true)
+                    .setAudioOffloadPreferences(audioOffloadPreferences)
                     .build()
             (trackSelector as DefaultTrackSelector).parameters = parameters
         }
@@ -205,12 +218,15 @@ class ExoplayerVideoActivity : SerenityActivity(), ExoplayerContract.ExoplayerVi
         // Control how much buffering is done before playback.  This is to help slower devices like lower end TVs such as TCL 4 Series
         // By buffering content, and caching data we can better improve video playback and reduce video stuttering
         val defaultLoadControl = DefaultLoadControl.Builder()
-                .setBufferDurationsMs(DefaultLoadControl.DEFAULT_MIN_BUFFER_MS, 60000, 1000, 2000)
-                .build()
+            .setBufferDurationsMs(DefaultLoadControl.DEFAULT_MIN_BUFFER_MS, 80000, 2500, 5000)
+            .setTargetBufferBytes(40 * 1024 * 1024) // Slightly higher memory cap (40MB)
+            .build()
 
-        val renderersFactory = DefaultRenderersFactory(this).setEnableAudioOffload(true)
 
-        return ExoPlayer.Builder(this, renderersFactory)
+        val renderersFactory = DefaultRenderersFactory(this)
+
+        return ExoPlayer.Builder(this)
+                .setRenderersFactory(renderersFactory)
                 .setTrackSelector(trackSelector)
                 .setLoadControl(defaultLoadControl)
                 .build()

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/video/player/VideoKeyCodeHandlerDelegate.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/video/player/VideoKeyCodeHandlerDelegate.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.content.SharedPreferences
 import android.util.Log
 import android.view.KeyEvent
-import com.google.android.exoplayer2.ExoPlayer
+import androidx.media3.exoplayer.ExoPlayer
 import org.greenrobot.eventbus.EventBus
 import toothpick.Toothpick
 import us.nineworlds.serenity.common.annotations.InjectionConstants
@@ -16,8 +16,8 @@ import javax.inject.Inject
 
 @OpenForTesting
 class VideoKeyCodeHandlerDelegate(
-        val player: ExoPlayer, val activity: Activity,
-        val presenter: ExoplayerContract.ExoplayerPresenter
+    val player: ExoPlayer, val activity: Activity,
+    val presenter: ExoplayerContract.ExoplayerPresenter
 ) {
 
   @Inject

--- a/serenity-app/src/main/res/layout-large/activity_exoplayer_video.xml
+++ b/serenity-app/src/main/res/layout-large/activity_exoplayer_video.xml
@@ -9,7 +9,7 @@
   android:keepScreenOn="true"
 >
 
-  <com.google.android.exoplayer2.ui.PlayerView
+  <androidx.media3.ui.PlayerView
     android:id="@+id/player_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/serenity-app/src/main/res/layout/exo_playback_control_view.xml
+++ b/serenity-app/src/main/res/layout/exo_playback_control_view.xml
@@ -72,7 +72,7 @@
       android:includeFontPadding="false"
       android:textColor="#FFBEBEBE" />
 
-    <com.google.android.exoplayer2.ui.DefaultTimeBar
+    <androidx.media3.ui.DefaultTimeBar
       android:id="@id/exo_progress"
       android:layout_width="0dp"
       android:layout_weight="1"

--- a/serenity-app/src/main/res/layout/exo_player_view.xml
+++ b/serenity-app/src/main/res/layout/exo_player_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
 
-  <com.google.android.exoplayer2.ui.AspectRatioFrameLayout
+  <androidx.media3.ui.AspectRatioFrameLayout
     android:id="@id/exo_content_frame"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -22,7 +22,7 @@
       android:layout_height="match_parent"
       android:scaleType="fitXY" />
 
-    <com.google.android.exoplayer2.ui.SubtitleView
+    <androidx.media3.ui.SubtitleView
       android:id="@id/exo_subtitles"
       android:layout_width="match_parent"
       android:layout_height="match_parent" />
@@ -45,7 +45,7 @@
       android:background="@color/exo_error_message_background_color"
       android:padding="16dp" />
 
-  </com.google.android.exoplayer2.ui.AspectRatioFrameLayout>
+  </androidx.media3.ui.AspectRatioFrameLayout>
 
   <FrameLayout
     android:id="@id/exo_overlay"

--- a/serenity-app/src/main/res/values/legacy_colors.xml
+++ b/serenity-app/src/main/res/values/legacy_colors.xml
@@ -28,4 +28,5 @@
   <color name="grey">#414141</color>
   <color name="emby_green">#007800</color>
   <color name="plex_orange">#E5A00D</color>
+  <color name="exo_error_message_background_color">#AA000000</color>
 </resources>

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/test/ShadowSubtitleView.java
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/test/ShadowSubtitleView.java
@@ -1,7 +1,8 @@
 package us.nineworlds.serenity.test;
 
-import com.google.android.exoplayer2.ui.CaptionStyleCompat;
-import com.google.android.exoplayer2.ui.SubtitleView;
+
+import androidx.media3.ui.CaptionStyleCompat;
+import androidx.media3.ui.SubtitleView;
 
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerVideoActivityTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerVideoActivityTest.kt
@@ -6,12 +6,12 @@ import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.SimpleExoPlayer
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
-import com.google.android.exoplayer2.trackselection.TrackSelectionArray
-import com.google.android.exoplayer2.trackselection.TrackSelector
-import com.google.android.exoplayer2.upstream.DataSource
+import androidx.media3.common.Player
+import androidx.media3.datasource.DataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import androidx.media3.exoplayer.trackselection.TrackSelectionArray
+import androidx.media3.exoplayer.trackselection.TrackSelector
 import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -48,7 +48,7 @@ open class ExoplayerVideoActivityTest : InjectingTest() {
     private val mockDataSourceFactory = mockk<DataSource.Factory>(relaxed = true)
     private val mockTrackSelector = mockk<TrackSelector>(relaxed = true)
     private val mockLogger = mockk<Logger>(relaxed = true)
-    private val mockPlayer = mockk<SimpleExoPlayer>(relaxed = true)
+    private val mockPlayer = mockk<ExoPlayer>(relaxed = true)
     private val mockTimeUtil = mockk<TimeUtil>(relaxed = true)
   }
 
@@ -71,7 +71,7 @@ open class ExoplayerVideoActivityTest : InjectingTest() {
   }
 
   @Test
-  fun bindsSimpleExoPlayerView() {
+  fun bindsExoPlayerView() {
     assertThat(activity.playerView).isNotNull()
   }
 
@@ -132,7 +132,7 @@ open class ExoplayerVideoActivityTest : InjectingTest() {
 
     spy.initializePlayer("http://www.example.com/start.mkv", 0)
 
-    assertThat(spy.player).isInstanceOf(SimpleExoPlayer::class.java)
+    assertThat(spy.player).isInstanceOf(ExoPlayer::class.java)
 
     verify { spy.createSimpleExoplayer() }
     verify { mockPlayer.addListener(any()) }

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/video/player/VideoKeyCodeHandlerDelegateTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/video/player/VideoKeyCodeHandlerDelegateTest.kt
@@ -2,10 +2,10 @@ package us.nineworlds.serenity.ui.video.player
 
 import android.content.SharedPreferences
 import android.view.KeyEvent
+import androidx.media3.exoplayer.ExoPlayer
 import assertk.assertThat
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
-import com.google.android.exoplayer2.SimpleExoPlayer
 import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -26,7 +26,7 @@ class VideoKeyCodeHandlerDelegateTest : InjectingTest() {
 
     companion object {
         private val mockPreferences = mockk<SharedPreferences>(relaxed = true)
-        private val mockMediaPlayer = mockk<SimpleExoPlayer>(relaxed = true)
+        private val mockMediaPlayer = mockk<ExoPlayer>(relaxed = true)
         private val mockPresenter = mockk<ExoplayerContract.ExoplayerPresenter>(relaxed = true)
         private val mockActivity = mockk<ExoplayerVideoActivity>(relaxed = true)
     }


### PR DESCRIPTION
This migrates to the Androidx.Media3 from Exoplayer v2. Several minor chnages in setup and playback were done to reduce stuttering and dynamically determine of Tunnelling is supported by the device to help improve playback on lower end devices.

Also increased the buffer size for the playback and network optimizations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Upgraded video playback engine to AndroidX Media3, improving stability and performance.
  * Enhanced audio and video codec tunneling support for compatible devices.
  * Optimized internal logging for improved system efficiency.
  * Updated media playback library dependencies for long-term compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->