### PR TITLE
feat: Add Title and Summary to video overlay of playing video

### DIFF
--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerContract.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerContract.kt
@@ -41,6 +41,9 @@ interface ExoplayerContract {
 
         @StateStrategyType(AddToEndSingleStrategy::class)
         fun toggleDebugView()
+
+        @StateStrategyType(AddToEndSingleStrategy::class)
+        fun setVideoInfo(title: String?, summary: String?)
     }
 
     interface ExoplayerPresenter {

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerPresenter.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerPresenter.kt
@@ -21,6 +21,7 @@ import us.nineworlds.serenity.common.annotations.OpenForTesting
 import us.nineworlds.serenity.common.rest.SerenityClient
 import us.nineworlds.serenity.core.logger.Logger
 import us.nineworlds.serenity.core.model.VideoContentInfo
+import us.nineworlds.serenity.core.model.impl.EpisodePosterInfo
 import us.nineworlds.serenity.core.util.AndroidHelper
 import us.nineworlds.serenity.events.video.OnScreenDisplayEvent
 import us.nineworlds.serenity.injection.ForVideoQueue
@@ -161,6 +162,7 @@ class ExoplayerPresenter :
     override fun playVideo() {
         val videoUrl: String = transcoderUrl()
         startPlaying()
+        viewState.setVideoInfo(if (video.seriesName != null) "${video.seriesName}\n${video.getTitle()}" else video.getTitle(), video.getSummary())
         viewState.updateSerenityDebugInfo(isTranscoding, video.videoCodec, video.audioCodec, 0)
         viewState.initializePlayer(videoUrl, video.resumeOffset)
     }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerVideoActivity.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerVideoActivity.kt
@@ -400,6 +400,14 @@ class ExoplayerVideoActivity :
         }
     }
 
+    override fun setVideoInfo(title: String?, summary: String?) {
+        val videoTitle = playerView.findViewById<TextView>(R.id.video_title)
+        val videoSummary = playerView.findViewById<TextView>(R.id.video_summary)
+
+        videoTitle?.text = title
+        videoSummary?.text = summary
+    }
+
     class SubtitleTrackNameProvider(val resources: Resources) : TrackNameProvider {
         override fun getTrackName(format: Format): String {
             val lang = format.language

--- a/serenity-app/src/main/res/layout/exo_player_control_view.xml
+++ b/serenity-app/src/main/res/layout/exo_player_control_view.xml
@@ -10,6 +10,35 @@
     android:layout_height="match_parent"
     android:background="#CC000000" />
 
+  <LinearLayout
+    android:id="@+id/video_info_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="top"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/overscan_start_padding"
+    android:paddingEnd="@dimen/overscan_end_padding"
+    android:paddingTop="@dimen/overscan_top_padding"
+    android:background="#80000000"
+  >
+    <TextView
+      android:id="@+id/video_title"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:textColor="@android:color/white"
+      android:textSize="24sp"
+      android:textStyle="bold" />
+
+    <TextView
+      android:id="@+id/video_summary"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:textColor="@android:color/white"
+      android:textSize="16sp"
+      android:maxLines="3"
+      android:ellipsize="end" />
+  </LinearLayout>
+
   <FrameLayout
     android:id="@id/exo_center_controls"
     android:layout_width="wrap_content"

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerPresenterTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerPresenterTest.kt
@@ -190,6 +190,9 @@ class ExoplayerPresenterTest : InjectingTest() {
         videoContentInfo.videoCodec = "h264"
         videoContentInfo.audioCodec = "ac3"
         videoContentInfo.directPlayUrl = "http://direct.url"
+        videoContentInfo.seriesTitle = null
+        videoContentInfo.setTitle("Title")
+        videoContentInfo.setSummary("Summary")
         presenter.video = videoContentInfo
 
         every { presenter.isDirectPlaySupportedForContainer(any()) } returns false
@@ -197,6 +200,7 @@ class ExoplayerPresenterTest : InjectingTest() {
 
         presenter.playVideo()
 
+        verify { mockView.setVideoInfo("Title", "Summary") }
         verify { mockView.updateSerenityDebugInfo(true, "h264", "ac3", 0) }
         verify { mockView.initializePlayer("http://transcode.url", 0) }
     }
@@ -207,12 +211,15 @@ class ExoplayerPresenterTest : InjectingTest() {
         videoContentInfo.videoCodec = "h264"
         videoContentInfo.audioCodec = "ac3"
         videoContentInfo.directPlayUrl = "http://direct.url"
+        videoContentInfo.setTitle("Title")
+        videoContentInfo.setSummary("Summary")
         presenter.video = videoContentInfo
 
         every { presenter.isDirectPlaySupportedForContainer(any()) } returns true
 
         presenter.playVideo()
 
+        verify { mockView.setVideoInfo("Title", "Summary") }
         verify { mockView.updateSerenityDebugInfo(false, "h264", "ac3", 0) }
         verify { mockView.initializePlayer("http://direct.url", 0) }
     }

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerVideoActivityTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/video/player/ExoplayerVideoActivityTest.kt
@@ -346,6 +346,20 @@ open class ExoplayerVideoActivityTest : InjectingTest() {
         }
     }
 
+    @Test
+    fun setVideoInfoUpdatesTitleAndSummary() {
+        val expectedTitle = "Test Title"
+        val expectedSummary = "Test Summary"
+
+        activity.setVideoInfo(expectedTitle, expectedSummary)
+
+        val videoTitle = activity.playerView.findViewById<TextView>(R.id.video_title)
+        val videoSummary = activity.playerView.findViewById<TextView>(R.id.video_summary)
+
+        assertThat(videoTitle.text.toString()).isEqualTo(expectedTitle)
+        assertThat(videoSummary.text.toString()).isEqualTo(expectedSummary)
+    }
+
     override fun installTestModules() {
         Toothpick.openScope(InjectionConstants.APPLICATION_SCOPE).installTestModules(object : Module() {
             init {
@@ -355,7 +369,7 @@ open class ExoplayerVideoActivityTest : InjectingTest() {
         scope.installTestModules(MockkTestingModule(), TestModule())
     }
 
-    inner class TestModule : Module() {
+    class TestModule : Module() {
 
         init {
             bind(ExoplayerPresenter::class.java).toInstance(mockExoPlayerPresenter)


### PR DESCRIPTION
Adds the Title and Summary information to the video overlay. For series it adds the Series Name and the Episode title along with the summary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a video information panel to the player interface, displaying the currently playing video's title and summary above the playback controls.

* **Tests**
  * Added test coverage for the new video metadata display functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->