### PR TITLE
Implements Paging Support for Issue #374

### DIFF
--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClient.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClient.kt
@@ -8,7 +8,6 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.File
 import java.io.IOException
 import java.util.UUID
-import kotlin.uuid.Uuid
 import me.jessyan.retrofiturlmanager.RetrofitUrlManager
 import okhttp3.Cache
 import okhttp3.OkHttpClient
@@ -237,7 +236,9 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
 
     override fun retrieveItemByIdCategory(key: String, category: String, types: Types): IMediaContainer = retrieveItemByIdCategory(key, category, types, 0, null)
 
-    override fun fetchSimilarItemById(itemId: String, types: Types): IMediaContainer {
+    override fun fetchSimilarItemById(itemId: String, types: Types): IMediaContainer = fetchSimilarItemById(itemId, types, 0, null)
+
+    override fun fetchSimilarItemById(itemId: String, types: Types, startIndex: Int, limit: Int?): IMediaContainer {
         val type = when (types) {
             Types.MOVIES -> "Movie"
             Types.SEASON -> "Season"
@@ -245,11 +246,16 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
             else -> "Episode"
         }
 
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+
         val call = usersService.fetchSimilarItemById(
             headerMap(),
             itemId = itemId,
             userId = userId!!,
-            includeItemType = "Movie"
+            includeItemType = type,
+            limit = limit
         )
 
         val results = call.executeOrThrow()
@@ -364,7 +370,9 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
         TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
     }
 
-    override fun retrieveEpisodes(key: String): IMediaContainer {
+    override fun retrieveEpisodes(key: String): IMediaContainer = retrieveEpisodes(key, 0, null)
+
+    override fun retrieveEpisodes(key: String, startIndex: Int, limit: Int?): IMediaContainer {
         if (userId == null) {
             userId = fetchUserId()
         }
@@ -373,7 +381,9 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
             userId = userId!!,
             parentId = key,
             includeItemType = "Episode",
-            genre = null
+            genre = null,
+            startIndex = startIndex,
+            limit = limit
         )
 
         val results = call.executeOrThrow()

--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClient.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClient.kt
@@ -288,14 +288,18 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
                         headerMap(),
                         userId = userId!!,
                         parentId = key,
-                        includeItemType = "Episode"
+                        includeItemType = "Episode",
+                        startIndex = startIndex,
+                        limit = limit
                     )
                 } else {
                     usersService.resumableItems(
                         headerMap(),
                         userId = userId!!,
                         parentId = key,
-                        includeItemType = type
+                        includeItemType = type,
+                        startIndex = startIndex,
+                        limit = limit
                     )
                 }
             }
@@ -306,14 +310,18 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
                         headerMap(),
                         userId = userId!!,
                         parentId = key,
-                        includeItemType = "Episode"
+                        includeItemType = "Episode",
+                        startIndex = startIndex,
+                        limit = limit
                     )
                 } else {
                     usersService.latestItems(
                         headerMap(),
                         userId = userId!!,
                         parentId = key,
-                        includeItemType = type
+                        includeItemType = type,
+                        startIndex = startIndex,
+                        limit = limit
                     )
                 }
             }
@@ -323,7 +331,9 @@ class EmbyAPIClient(val context: Context, baseUrl: String = "http://localhost:80
                     headerMap(),
                     userId = userId!!,
                     parentId = key,
-                    includeItemType = type
+                    includeItemType = type,
+                    startIndex = startIndex,
+                    limit = limit
                 )
             }
 

--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/UsersService.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/UsersService.kt
@@ -68,7 +68,9 @@ interface UsersService {
         @Query("Filters") filters: String = "IsResumable",
         @Suppress("ktlint:standard:max-line-length")
         @Query("Fields") fields: String = "Overview,MediaStreams,Studios,ParentId,Genres,MediaSources,UserData,OfficialRating,CommunityRating",
-        @Query("IncludeItemTypes") includeItemType: String? = null
+        @Query("IncludeItemTypes") includeItemType: String? = null,
+        @Query("StartIndex") startIndex: Int = 0,
+        @Query("Limit") limit: Int? = null
     ): Call<QueryResult>
 
     @GET("/emby/Users/{userId}/Items")
@@ -81,10 +83,12 @@ interface UsersService {
         @Query("SortOrder") sortOrder: String = "Descending",
         @Query("Filters") filters: String = "IsUnplayed",
         @Query("Fields") fields: String = "Overview,MediaStreams,Studios,ParentId,Genres,MediaSources,UserData,OfficialRating,CommunityRating",
-        @Query("IncludeItemTypes") includeItemType: String? = null
+        @Query("IncludeItemTypes") includeItemType: String? = null,
+        @Query("StartIndex") startIndex: Int = 0,
+        @Query("Limit") limit: Int? = null
     ): Call<QueryResult>
 
-    @GET("/emby/Users/{userId}/Items?Limit=20")
+    @GET("/emby/Users/{userId}/Items")
     fun latestItems(
         @HeaderMap headerMap: Map<String, String>,
         @Path("userId") userId: String,
@@ -96,7 +100,9 @@ interface UsersService {
         @Query("Filters") filters: String = "IsNotFolder,IsUnPlayed",
         @Suppress("ktlint:standard:max-line-length")
         @Query("Fields") fields: String = "Overview,MediaStreams,Studios,ParentId,Genres,MediaSources,UserData,OfficialRating,CommunityRating",
-        @Query("IncludeItemTypes") includeItemType: String? = null
+        @Query("IncludeItemTypes") includeItemType: String? = null,
+        @Query("StartIndex") startIndex: Int = 0,
+        @Query("Limit") limit: Int? = null
     ): Call<QueryResult>
 
     @GET("/emby/Users/{userId}/Items/{itemId}")

--- a/emby-lib/src/test/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClientTest.kt
+++ b/emby-lib/src/test/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClientTest.kt
@@ -7,6 +7,7 @@ import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
+import net.danlew.android.joda.JodaTimeAndroid
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,10 +27,11 @@ class EmbyAPIClientTest {
     @Before
     fun setUp() {
         ShadowLog.stream = System.out
+        JodaTimeAndroid.init(ApplicationProvider.getApplicationContext())
 
         client = EmbyAPIClient(context = ApplicationProvider.getApplicationContext())
         // Update this for local testing of the client and make sure it works
-        client.updateBaseUrl("http://yourserver:yourport")
+        client.updateBaseUrl("http://192.168.68.97:8096")
         prefs = client.prefs
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ kotlinKSPVersion = "2.2.21-2.0.4"
 androidPluginVersion = "8.13.1"
 leanbackPreferenceVersion = "1.2.0"
 leanbackVersion = "1.2.0"
+leanbackPagingVersion = "1.1.0"
 legacySupportV4Version = "1.0.0"
 lifecycleVersion = "2.9.4"
 materialVersion = "1.12.0"
@@ -29,6 +30,7 @@ moxy = "2.2.2"
 moxyAppCompatVersion = "2.2.2"
 moxyCompilerVersion = "2.2.2"
 moxyKtxVersion = "2.2.2"
+pagingVersion = "3.4.0"
 percentlayoutVersion = "1.0.0"
 recyclerviewAnimatorsVersion = "4.0.2"
 targetSdkVersion = "35"
@@ -74,9 +76,11 @@ androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "frag
 androidx-fragment-testing = { module = "androidx.fragment:fragment-testing", version.ref = "fragmentKtxVersion" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junit" }
 androidx-leanback = { module = "androidx.leanback:leanback", version.ref = "leanbackVersion" }
+androidx-leanback-paging = { module = "androidx.leanback:leanback-paging", version.ref = "leanbackPagingVersion" }
 androidx-leanback-preference = { module = "androidx.leanback:leanback-preference", version.ref = "leanbackPreferenceVersion" }
 androidx-legacy-support-v4 = { module = "androidx.legacy:legacy-support-v4", version.ref = "legacySupportV4Version" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref="lifecycleVersion"}
+androidx-paging-runtime-ktx = { module = "androidx.paging:paging-runtime-ktx", version.ref = "pagingVersion" }
 androidx-percentlayout = { module = "androidx.percentlayout:percentlayout", version.ref = "percentlayoutVersion" }
 androidx-recycler-view = { module = "androidx.recyclerview:recyclerview", version.ref = "androidxRecyclerViewVersion"}
 commons-io = { module = "commons-io:commons-io", version.ref = "commonsIo" }

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClient.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClient.kt
@@ -235,7 +235,9 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
 
     override fun retrieveItemByIdCategory(key: String, category: String, types: Types): IMediaContainer = retrieveItemByIdCategory(key, category, types, 0, null)
 
-    override fun fetchSimilarItemById(itemId: String, types: Types): IMediaContainer {
+    override fun fetchSimilarItemById(itemId: String, types: Types): IMediaContainer = fetchSimilarItemById(itemId, types, 0, null)
+
+    override fun fetchSimilarItemById(itemId: String, types: Types, startIndex: Int, limit: Int?): IMediaContainer {
         val type = when (types) {
             Types.MOVIES -> "Movie"
             Types.SEASON -> "Season"
@@ -243,7 +245,17 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
             else -> "Episode"
         }
 
-        val call = usersService.fetchSimilarItemById(headerMap(), itemId = itemId, userId = userId!!, includeItemType = "Movie")
+        if (userId == null) {
+            userId = fetchUserId()
+        }
+
+        val call = usersService.fetchSimilarItemById(
+            headerMap(),
+            itemId = itemId,
+            userId = userId!!,
+            includeItemType = type,
+            limit = limit
+        )
 
         val results = call.executeOrThrow()
         return JellyfinMediaContainerAdaptor().createVideoList(results.items, fetchAccessToken())
@@ -271,22 +283,57 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         val call = when (category) {
             "ondeck" -> {
                 if (type == "Season" || type == "Series") {
-                    usersService.resumableItems(headerMap(), userId = userId!!, parentId = key, includeItemType = "Episode")
+                    usersService.resumableItems(
+                        headerMap(),
+                        userId = userId!!,
+                        parentId = key,
+                        includeItemType = "Episode",
+                        startIndex = startIndex,
+                        limit = limit
+                    )
                 } else {
-                    usersService.resumableItems(headerMap(), userId = userId!!, parentId = key, includeItemType = type)
+                    usersService.resumableItems(
+                        headerMap(),
+                        userId = userId!!,
+                        parentId = key,
+                        includeItemType = type,
+                        startIndex = startIndex,
+                        limit = limit
+                    )
                 }
             }
 
             "recentlyAdded" -> {
                 if (type == "Season" || type == "Series") {
-                    usersService.latestItems(headerMap(), userId = userId!!, parentId = key, includeItemType = "Episode")
+                    usersService.latestItems(
+                        headerMap(),
+                        userId = userId!!,
+                        parentId = key,
+                        includeItemType = "Episode",
+                        startIndex = startIndex,
+                        limit = limit
+                    )
                 } else {
-                    usersService.latestItems(headerMap(), userId = userId!!, parentId = key, includeItemType = type)
+                    usersService.latestItems(
+                        headerMap(),
+                        userId = userId!!,
+                        parentId = key,
+                        includeItemType = type,
+                        startIndex = startIndex,
+                        limit = limit
+                    )
                 }
             }
 
             "unwatched" -> {
-                usersService.unwatchedItems(headerMap(), userId = userId!!, parentId = key, includeItemType = type)
+                usersService.unwatchedItems(
+                    headerMap(),
+                    userId = userId!!,
+                    parentId = key,
+                    includeItemType = type,
+                    startIndex = startIndex,
+                    limit = limit
+                )
             }
 
             else -> {
@@ -332,7 +379,9 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
     }
 
-    override fun retrieveEpisodes(key: String): IMediaContainer {
+    override fun retrieveEpisodes(key: String): IMediaContainer = retrieveEpisodes(key, 0, null)
+
+    override fun retrieveEpisodes(key: String, startIndex: Int, limit: Int?): IMediaContainer {
         if (userId == null) {
             userId = fetchUserId()
         }
@@ -341,7 +390,9 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
             userId = userId!!,
             parentId = key,
             includeItemType = "Episode",
-            genre = null
+            genre = null,
+            startIndex = startIndex,
+            limit = limit
         )
 
         val results = call.executeOrThrow()
@@ -407,7 +458,9 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         return result.isSuccessful
     }
 
-    override fun progress(key: String, offset: String): Boolean {
+    override fun progress(key: String, offset: String): Boolean = progress(key, offset, null)
+
+    override fun progress(key: String, offset: String, playSessionId: String?): Boolean {
         if (userId == null) {
             userId = fetchUserId()
         }
@@ -419,10 +472,6 @@ class JellyfinAPIClient(val context: Context, baseUrl: String = "http://localhos
         val result = call.execute()
 
         return result.isSuccessful
-    }
-
-    override fun progress(key: String, offset: String, playSessionId: String?): Boolean {
-        TODO("Not yet implemented")
     }
 
     override fun createMediaTagURL(resourceType: String, resourceName: String, identifier: String): String {

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinUsersService.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinUsersService.kt
@@ -66,7 +66,9 @@ interface JellyfinUsersService {
         @Query("Filters") filters: String = "IsResumable",
         @Suppress("ktlint:standard:max-line-length")
         @Query("Fields") fields: String = "Overview,MediaStreams,Studios,ParentId,Genres,MediaSources,UserData,OfficialRating,CommunityRating",
-        @Query("IncludeItemTypes") includeItemType: String? = null
+        @Query("IncludeItemTypes") includeItemType: String? = null,
+        @Query("StartIndex") startIndex: Int = 0,
+        @Query("Limit") limit: Int? = null
     ): Call<QueryResult>
 
     @GET("/Users/{userId}/Items")
@@ -80,7 +82,9 @@ interface JellyfinUsersService {
         @Query("Filters") filters: String = "IsUnplayed",
         @Suppress("ktlint:standard:max-line-length")
         @Query("Fields") fields: String = "Overview,MediaStreams,Studios,ParentId,Genres,MediaSources,UserData,OfficialRating,CommunityRating",
-        @Query("IncludeItemTypes") includeItemType: String? = null
+        @Query("IncludeItemTypes") includeItemType: String? = null,
+        @Query("StartIndex") startIndex: Int = 0,
+        @Query("Limit") limit: Int? = null
     ): Call<QueryResult>
 
     @GET("/Users/{userId}/Items?Limit=20")
@@ -95,7 +99,9 @@ interface JellyfinUsersService {
         @Query("Filters") filters: String = "IsNotFolder,IsUnPlayed",
         @Suppress("ktlint:standard:max-line-length")
         @Query("Fields") fields: String = "Overview,MediaStreams,Studios,ParentId,Genres,MediaSources,UserData,OfficialRating,CommunityRating",
-        @Query("IncludeItemTypes") includeItemType: String? = null
+        @Query("IncludeItemTypes") includeItemType: String? = null,
+        @Query("StartIndex") startIndex: Int = 0,
+        @Query("Limit") limit: Int? = null
     ): Call<QueryResult>
 
     @GET("/Users/{userId}/Items/{itemId}")

--- a/lint-rules/src/main/java/us/nineworlds/serenity/lint/LegacyPreferenceDetector.kt
+++ b/lint-rules/src/main/java/us/nineworlds/serenity/lint/LegacyPreferenceDetector.kt
@@ -1,18 +1,31 @@
 package us.nineworlds.serenity.lint
 
 import com.android.tools.lint.client.api.UElementHandler
-import com.android.tools.lint.detector.api.*
-import org.jetbrains.uast.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UFile
+import org.jetbrains.uast.UImportStatement
+import org.jetbrains.uast.UQualifiedReferenceExpression
+import org.jetbrains.uast.USimpleNameReferenceExpression
+import org.jetbrains.uast.getParentOfType
 
-class LegacyPreferenceDetector : Detector(), SourceCodeScanner {
+class LegacyPreferenceDetector :
+    Detector(),
+    SourceCodeScanner {
 
-    override fun getApplicableUastTypes(): List<Class<out UElement>> {
-        return listOf(
-            UImportStatement::class.java,
-            UCallExpression::class.java,
-            USimpleNameReferenceExpression::class.java
-        )
-    }
+    override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(
+        UImportStatement::class.java,
+        UCallExpression::class.java,
+        USimpleNameReferenceExpression::class.java
+    )
 
     override fun createUastHandler(context: JavaContext): UElementHandler? {
         val packageName = context.uastFile?.packageName
@@ -49,10 +62,10 @@ class LegacyPreferenceDetector : Detector(), SourceCodeScanner {
                             return
                         }
                         if (p is UQualifiedReferenceExpression) {
-                             val selector = p.selector
-                             if (selector is UCallExpression && selector.methodName == "getDefaultSharedPreferences") {
-                                 return
-                             }
+                            val selector = p.selector
+                            if (selector is UCallExpression && selector.methodName == "getDefaultSharedPreferences") {
+                                return
+                            }
                         }
                         p = p.uastParent
                     }
@@ -76,7 +89,7 @@ class LegacyPreferenceDetector : Detector(), SourceCodeScanner {
             override fun visitCallExpression(node: UCallExpression) {
                 val methodName = node.methodName
                 if (methodName == "getSharedPreferences") {
-                     context.report(
+                    context.report(
                         ISSUE,
                         node,
                         context.getLocation(node),

--- a/lint-rules/src/test/java/us/nineworlds/serenity/lint/LegacyPreferenceDetectorTest.kt
+++ b/lint-rules/src/test/java/us/nineworlds/serenity/lint/LegacyPreferenceDetectorTest.kt
@@ -1,7 +1,7 @@
 package us.nineworlds.serenity.lint
 
-import com.android.tools.lint.checks.infrastructure.LintDetectorTest.kotlin
 import com.android.tools.lint.checks.infrastructure.LintDetectorTest.java
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest.kotlin
 import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
 import com.android.tools.lint.checks.infrastructure.TestMode
 import org.junit.Test
@@ -72,7 +72,7 @@ class LegacyPreferenceDetectorTest {
             import android.content.SharedPreferences
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             0 errors, 1 warnings
-        """.trimIndent()
+                """.trimIndent()
             )
     }
 
@@ -104,7 +104,7 @@ class LegacyPreferenceDetectorTest {
                     val prefs = context.getSharedPreferences("test", 0)
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             0 errors, 1 warnings
-        """.trimIndent()
+                """.trimIndent()
             )
     }
 
@@ -140,7 +140,7 @@ class LegacyPreferenceDetectorTest {
                     val prefs = PreferenceManager.getDefaultSharedPreferences(null)
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             0 errors, 2 warnings
-        """.trimIndent()
+                """.trimIndent()
             )
     }
 

--- a/paging_support_plan.md
+++ b/paging_support_plan.md
@@ -1,0 +1,78 @@
+# Serenity for Android: Leanback Paging Support Implementation Plan
+
+This document outlines the multi-stage plan to implement paging support in the `serenity-app` module using `androidx.leanback:leanback-paging` and `androidx.paging:paging-runtime-ktx`.
+
+## Status: Phase 3 Completed - Moving to Phase 4
+
+## Overview
+The goal is to implement paging for Movies, TV Shows, and Seasons.
+- **Initial Load**: 30 items.
+- **Subsequent Loads**: 15 items.
+- **Backend**: Emby-lib / Jellyfin-lib (via `SerenityClient`).
+
+---
+
+## Phase 1: Dependency Acquisition
+**Goal**: Add the necessary libraries to the project.
+
+- [x] **Task 1.1**: Update `serenity-app/build.gradle.kts` with Paging 3 and Leanback Paging dependencies.
+- [x] **Task 1.2**: Perform a Gradle Sync.
+
+---
+
+## Phase 2: Core Plumbing (Interface & Repository Updates)
+**Goal**: Update shared interfaces to support pagination parameters.
+
+- [x] **Task 2.1**: Update `SerenityClient` interface (`serenity-common`).
+- [x] **Task 2.2**: Update `CategoryRepository` (`serenity-app`).
+- [x] **Task 2.3**: Update `VideoRepository` (`serenity-app`).
+- [x] **Task 2.4**: Run existing unit tests to ensure no regressions in basic data fetching.
+
+---
+
+## Phase 3: Paging Logic (Sources)
+**Goal**: Create `PagingSource` implementations to handle the 30/15 logic.
+
+- [x] **Task 3.1**: Create `VideoCategoryPagingSource`.
+- [x] **Task 3.2**: Create `EpisodePagingSource`.
+- [x] **Task 3.3**: Create `SimilarItemsPagingSource`.
+
+---
+
+## Phase 4: Presenter & View Interface Updates
+**Goal**: Refactor MVP components from static Lists to Paging Flows.
+
+- [ ] **Task 4.1**: Update `MainMenuView` and `DetailsView` interface definitions to support `PagingData`.
+- [ ] **Task 4.2**: Refactor `MainMenuPresenter`.
+    - Change `processesCategories` to initialize a `Flow<PagingData<VideoCategory>>` for each row.
+- [ ] **Task 4.3**: Refactor `DetailsMVPPresenter`.
+    - Update `updateSeries` and `loadSimilarItems` to return Paging flows.
+
+---
+
+## Phase 5: UI Integration (Leanback)
+**Goal**: Connect the Paging Flows to the Leanback UI.
+
+- [ ] **Task 5.1**: Implement a generic `SerenityPagingDataAdapter` extending `androidx.leanback.paging.PagingDataAdapter`.
+- [ ] **Task 5.2**: Update `MainFragment` (or relevant Browse fragments) to use the new adapter.
+- [ ] **Task 5.3**: Update `VideoDetailsFragment` to use the new adapter for episode and similar item rows.
+
+---
+
+## Phase 6: Date/Time API Migration
+**Goal**: Migrate from Joda-Time to the built-in `java.time` (Java 8+) API.
+
+- [ ] **Task 6.1**: Audit Joda-Time usage across the project (e.g., `LocalDateTime`, `LocalDateJsonAdapter`).
+- [ ] **Task 6.2**: Replace `org.joda.time` imports with `java.time` equivalents.
+- [ ] **Task 6.3**: Update Moshi adapters for `java.time`.
+- [ ] **Task 6.4**: Remove `net.danlew:android.joda` dependency and `JodaTimeAndroid.init()` calls.
+
+---
+
+## Verification & Testing Steps
+1. **Unit Tests**:
+    - [x] Test `PagingSource` implementations with mocked `SerenityClient`.
+    - [x] Verify `startIndex` and `limit` calculations.
+2. **Manual Verification**:
+    - Scroll through a large category (e.g., "All Movies") and observe network calls for 30 then 15 items.
+    - Verify "watched" status updates correctly across paged items.

--- a/paging_support_plan.md
+++ b/paging_support_plan.md
@@ -2,7 +2,7 @@
 
 This document outlines the multi-stage plan to implement paging support in the `serenity-app` module using `androidx.leanback:leanback-paging` and `androidx.paging:paging-runtime-ktx`.
 
-## Status: Phase 3 Completed - Moving to Phase 4
+## Status: Phase 5 Completed - Moving to Phase 6
 
 ## Overview
 The goal is to implement paging for Movies, TV Shows, and Seasons.
@@ -42,10 +42,10 @@ The goal is to implement paging for Movies, TV Shows, and Seasons.
 ## Phase 4: Presenter & View Interface Updates
 **Goal**: Refactor MVP components from static Lists to Paging Flows.
 
-- [ ] **Task 4.1**: Update `MainMenuView` and `DetailsView` interface definitions to support `PagingData`.
-- [ ] **Task 4.2**: Refactor `MainMenuPresenter`.
+- [x] **Task 4.1**: Update `MainMenuView` and `DetailsView` interface definitions to support `PagingData`.
+- [x] **Task 4.2**: Refactor `MainMenuPresenter`.
     - Change `processesCategories` to initialize a `Flow<PagingData<VideoCategory>>` for each row.
-- [ ] **Task 4.3**: Refactor `DetailsMVPPresenter`.
+- [x] **Task 4.3**: Refactor `DetailsMVPPresenter`.
     - Update `updateSeries` and `loadSimilarItems` to return Paging flows.
 
 ---
@@ -53,9 +53,11 @@ The goal is to implement paging for Movies, TV Shows, and Seasons.
 ## Phase 5: UI Integration (Leanback)
 **Goal**: Connect the Paging Flows to the Leanback UI.
 
-- [ ] **Task 5.1**: Implement a generic `SerenityPagingDataAdapter` extending `androidx.leanback.paging.PagingDataAdapter`.
-- [ ] **Task 5.2**: Update `MainFragment` (or relevant Browse fragments) to use the new adapter.
-- [ ] **Task 5.3**: Update `VideoDetailsFragment` to use the new adapter for episode and similar item rows.
+- [x] **Task 5.1**: Implement a generic `SerenityPagingDataAdapter` extending `androidx.leanback.paging.PagingDataAdapter`.
+- [x] **Task 5.2**: Fix compilation errors and update `MainMenuFragment` to handle `PagingData`.
+- [x] **Task 5.3**: Update `MainMenuVideoContentVerticalGridFragment` and its adapters to support Paging.
+- [x] **Task 5.4**: Fix compilation errors and update `DetailsFragment` to handle `PagingData` for episodes and similar items.
+- [x] **Task 5.5**: Fix any remaining compilation errors in `DetailsMVPPresenter`.
 
 ---
 

--- a/paging_support_plan.md
+++ b/paging_support_plan.md
@@ -76,5 +76,5 @@ The goal is to implement paging for Movies, TV Shows, and Seasons.
     - [x] Test `PagingSource` implementations with mocked `SerenityClient`.
     - [x] Verify `startIndex` and `limit` calculations.
 2. **Manual Verification**:
-    - Scroll through a large category (e.g., "All Movies") and observe network calls for 30 then 15 items.
-    - Verify "watched" status updates correctly across paged items.
+    - [x] Scroll through a large category (e.g., "All Movies") and observe network calls for 30 then 15 items.
+    - [x] Verify "watched" status updates correctly across paged items.

--- a/prompts/mvp_viewmodel_prompt.txt
+++ b/prompts/mvp_viewmodel_prompt.txt
@@ -1,0 +1,43 @@
+Task: Refactor Moxy MVP to Manual Lifecycle-Aware MVP (ViewModel-backed)
+
+Context:
+The project is migrating away from the unmaintained Moxy framework. The goal is to retain a strict Contract-driven, Passive View MVP architecture but use standard Android Jetpack ViewModels to handle configuration changes and lifecycle events.
+
+Constraints:
+1. No Reactive Streams: DO NOT use Kotlin Flow, Channels, or RxJava for this refactor. Keep the direct method-call structure between Presenter and View.
+2. Survival: The Presenter must extend 'androidx.lifecycle.ViewModel' to survive configuration changes.
+3. Lifecycle: The Presenter must implement 'androidx.lifecycle.DefaultLifecycleObserver' to manage view attachment/detachment.
+4. DI: Use Toothpick. Inject the Presenter via a 'Provider<Presenter>' inside a 'ViewModelProvider.Factory'.
+5. Hard Constraint: Remove all Moxy annotations (@InjectPresenter, @ProvidePresenter, @RegisterStrategy).
+
+Step 1: Update the Presenter
+- Extend 'AndroidViewModel(application)'.
+- Implement 'DefaultLifecycleObserver' and the existing Contract.Presenter interface.
+- Add 'private var view: Contract.View? = null'.
+- Create 'fun attachView(view: Contract.View)' and 'fun detachView()'.
+- Override 'onStart(owner: LifecycleOwner)' to call logic if needed, and 'onDestroy(owner: LifecycleOwner)' to call 'detachView()'.
+- Ensure all business logic calls 'view?.method()' instead of the Moxy view-proxy.
+
+Step 2: Update the Activity (The View)
+- Implement the Contract.View interface.
+- Inject 'Provider<Presenter>' via Toothpick.
+- Initialize the presenter using:
+  private val presenter: MyPresenter by viewModels {
+      object : ViewModelProvider.Factory {
+          override fun <T : ViewModel> create(modelClass: Class<T>): T = presenterProvider.get() as T
+      }
+  }
+- In 'onCreate()':
+    1. Call 'presenter.attachView(this)'.
+    2. Call 'lifecycle.addObserver(presenter)'.
+- Remove all Moxy-related field annotations and imports.
+
+Step 3: Testing Compliance
+- Ensure unit tests using MockK remain functional.
+- Mocks should be 'mockk(relaxed = true)'.
+- The test should call 'presenter.attachView(mockView)' during setup.
+
+Compliance Check: [Frameworks Verified] [MockK Verified] [Permission Pending]
+
+Agent Instructions:
+Review 'ExoplayerVideoActivity.kt' and 'ExoplayerPresenter.kt'. Draft a plan to convert them to this manual MVP style. DO NOT start coding until the plan is approved.

--- a/serenity-app/build.gradle.kts
+++ b/serenity-app/build.gradle.kts
@@ -130,6 +130,8 @@ dependencies {
     implementation(project(":serenity-common"))
 
     implementation(libs.androidx.recycler.view)
+    implementation(libs.androidx.paging.runtime.ktx)
+    implementation(libs.androidx.leanback.paging)
 
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.crashlytics)

--- a/serenity-app/src/main/java/us/nineworlds/serenity/fragments/MainMenuFragment.kt
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/fragments/MainMenuFragment.kt
@@ -32,6 +32,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.fragment.app.FragmentContainerView
 import androidx.leanback.widget.HorizontalGridView
+import androidx.paging.PagingData
 import javax.inject.Inject
 import javax.inject.Provider
 import moxy.ktx.moxyPresenter
@@ -111,12 +112,12 @@ class MainMenuFragment :
         videoContainer.setupGallery(categories)
     }
 
-    override fun updateCategories(category: CategoryInfo, items: List<VideoCategory>) {
+    override fun updateCategories(category: CategoryInfo, pagingData: PagingData<VideoCategory>) {
         val container = requireActivity().findViewById<FragmentContainerView>(R.id.video_content_fragment)
 
         val videoContainer = container.getFragment<MainMenuVideoContentVerticalGridFragment>()
 
-        videoContainer.updateCategory(category, items)
+        videoContainer.updateCategory(category, pagingData)
     }
 
     override fun clearCategories() {

--- a/serenity-app/src/main/java/us/nineworlds/serenity/fragments/MainMenuVideoContentVerticalGridFragment.kt
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/fragments/MainMenuVideoContentVerticalGridFragment.kt
@@ -5,13 +5,16 @@ import android.os.Bundle
 import android.widget.ImageView
 import androidx.leanback.app.RowsSupportFragment
 import androidx.leanback.widget.ArrayObjectAdapter
-import androidx.leanback.widget.DiffCallback
 import androidx.leanback.widget.HeaderItem
 import androidx.leanback.widget.ListRow
 import androidx.leanback.widget.ListRowPresenter
+import androidx.lifecycle.lifecycleScope
+import androidx.paging.PagingData
+import androidx.recyclerview.widget.DiffUtil
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 import toothpick.Toothpick
 import us.nineworlds.serenity.R
 import us.nineworlds.serenity.common.annotations.InjectionConstants
@@ -20,6 +23,7 @@ import us.nineworlds.serenity.core.model.CategoryInfo
 import us.nineworlds.serenity.core.model.CategoryVideoInfo
 import us.nineworlds.serenity.core.model.VideoCategory
 import us.nineworlds.serenity.ui.activity.leanback.details.DetailsActivity
+import us.nineworlds.serenity.ui.leanback.adapters.SerenityPagingDataAdapter
 import us.nineworlds.serenity.ui.leanback.presenters.CategoryVideoPresenter
 import us.nineworlds.serenity.ui.util.VideoPlayerIntentUtils
 
@@ -31,12 +35,23 @@ class MainMenuVideoContentVerticalGridFragment : RowsSupportFragment() {
     private val videoContentRowsPresenter = ListRowPresenter()
     private val videoContentAdapter = ArrayObjectAdapter(videoContentRowsPresenter)
 
+    private val videoCategoryDiffCallback = object : DiffUtil.ItemCallback<VideoCategory>() {
+        override fun areItemsTheSame(oldItem: VideoCategory, newItem: VideoCategory): Boolean =
+            oldItem.item.id() == newItem.item.id()
+
+        override fun areContentsTheSame(oldItem: VideoCategory, newItem: VideoCategory): Boolean =
+            oldItem == newItem
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         Toothpick.inject(this, Toothpick.openScope(InjectionConstants.APPLICATION_SCOPE))
         super.onCreate(savedInstanceState)
         adapter = videoContentAdapter
 
         setOnItemViewClickedListener { _, item, _, _ ->
+            if (item == null) {
+                return@setOnItemViewClickedListener
+            }
             val videoCategory = item as VideoCategory
 
             when {
@@ -64,7 +79,7 @@ class MainMenuVideoContentVerticalGridFragment : RowsSupportFragment() {
             }
         }
 
-        setOnItemViewSelectedListener { itemViewHolder, item, rowViewHolder, row ->
+        setOnItemViewSelectedListener { _, item, _, _ ->
             item?.let {
                 val videoCategory = item as VideoCategory
 
@@ -77,28 +92,22 @@ class MainMenuVideoContentVerticalGridFragment : RowsSupportFragment() {
 
     fun clearGallery() = videoContentAdapter.clear()
 
-    fun updateCategory(categoryInfo: CategoryInfo, contentList: List<VideoCategory>) {
+    fun updateCategory(categoryInfo: CategoryInfo, pagingData: PagingData<VideoCategory>) {
         val rows = videoContentAdapter.unmodifiableList<ListRow>()
         val row = rows.find { row ->
             row.headerItem.name == categoryInfo.categoryDetail
         }
-        row?.let { row ->
-            val adapter = row.adapter as ArrayObjectAdapter
-            adapter.setItems(
-                contentList,
-                object : DiffCallback<VideoCategory>() {
-                    override fun areItemsTheSame(oldItem: VideoCategory, newItem: VideoCategory): Boolean = oldItem.item.id() == newItem.item.id()
-
-                    override fun areContentsTheSame(oldItem: VideoCategory, newItem: VideoCategory): Boolean = oldItem.equals(newItem)
-                }
-            )
+        row?.let { listRow ->
+            val adapter = listRow.adapter as SerenityPagingDataAdapter<VideoCategory>
+            viewLifecycleOwner.lifecycleScope.launch {
+                adapter.submitData(pagingData)
+            }
         }
     }
 
     fun setupGallery(categories: CategoryVideoInfo) {
         for (category in categories.categories) {
-            val listContentRowAdapter = ArrayObjectAdapter(CategoryVideoPresenter())
-            listContentRowAdapter.addAll(0, emptyList<VideoCategory>())
+            val listContentRowAdapter = SerenityPagingDataAdapter(CategoryVideoPresenter(), videoCategoryDiffCallback)
 
             val header = HeaderItem(category.categoryDetail)
             val imageListRow = ListRow(header, listContentRowAdapter)

--- a/serenity-app/src/main/java/us/nineworlds/serenity/fragments/MainMenuVideoContentVerticalGridFragment.kt
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/fragments/MainMenuVideoContentVerticalGridFragment.kt
@@ -13,6 +13,7 @@ import androidx.paging.PagingData
 import androidx.recyclerview.widget.DiffUtil
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 import toothpick.Toothpick
@@ -34,6 +35,7 @@ class MainMenuVideoContentVerticalGridFragment : RowsSupportFragment() {
 
     private val videoContentRowsPresenter = ListRowPresenter()
     private val videoContentAdapter = ArrayObjectAdapter(videoContentRowsPresenter)
+    private val adapterMap = ConcurrentHashMap<String, SerenityPagingDataAdapter<VideoCategory>>()
 
     private val videoCategoryDiffCallback = object : DiffUtil.ItemCallback<VideoCategory>() {
         override fun areItemsTheSame(oldItem: VideoCategory, newItem: VideoCategory): Boolean =
@@ -90,15 +92,13 @@ class MainMenuVideoContentVerticalGridFragment : RowsSupportFragment() {
         }
     }
 
-    fun clearGallery() = videoContentAdapter.clear()
+    fun clearGallery() {
+        adapterMap.clear()
+        videoContentAdapter.clear()
+    }
 
     fun updateCategory(categoryInfo: CategoryInfo, pagingData: PagingData<VideoCategory>) {
-        val rows = videoContentAdapter.unmodifiableList<ListRow>()
-        val row = rows.find { row ->
-            row.headerItem.name == categoryInfo.categoryDetail
-        }
-        row?.let { listRow ->
-            val adapter = listRow.adapter as SerenityPagingDataAdapter<VideoCategory>
+        adapterMap[categoryInfo.categoryDetail]?.let { adapter ->
             viewLifecycleOwner.lifecycleScope.launch {
                 adapter.submitData(pagingData)
             }
@@ -106,8 +106,13 @@ class MainMenuVideoContentVerticalGridFragment : RowsSupportFragment() {
     }
 
     fun setupGallery(categories: CategoryVideoInfo) {
+        adapterMap.clear()
+        videoContentAdapter.clear()
         for (category in categories.categories) {
             val listContentRowAdapter = SerenityPagingDataAdapter(CategoryVideoPresenter(), videoCategoryDiffCallback)
+            category.categoryDetail?.let { detail ->
+                adapterMap[detail] = listContentRowAdapter
+            }
 
             val header = HeaderItem(category.categoryDetail)
             val imageListRow = ListRow(header, listContentRowAdapter)

--- a/serenity-app/src/main/java/us/nineworlds/serenity/fragments/MainMenuVideoContentVerticalGridFragment.kt
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/fragments/MainMenuVideoContentVerticalGridFragment.kt
@@ -38,11 +38,9 @@ class MainMenuVideoContentVerticalGridFragment : RowsSupportFragment() {
     private val adapterMap = ConcurrentHashMap<String, SerenityPagingDataAdapter<VideoCategory>>()
 
     private val videoCategoryDiffCallback = object : DiffUtil.ItemCallback<VideoCategory>() {
-        override fun areItemsTheSame(oldItem: VideoCategory, newItem: VideoCategory): Boolean =
-            oldItem.item.id() == newItem.item.id()
+        override fun areItemsTheSame(oldItem: VideoCategory, newItem: VideoCategory): Boolean = oldItem.item.id() == newItem.item.id()
 
-        override fun areContentsTheSame(oldItem: VideoCategory, newItem: VideoCategory): Boolean =
-            oldItem == newItem
+        override fun areContentsTheSame(oldItem: VideoCategory, newItem: VideoCategory): Boolean = oldItem == newItem
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/model/impl/EpisodeMediaContainer.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/model/impl/EpisodeMediaContainer.kt
@@ -11,6 +11,7 @@ import us.nineworlds.serenity.core.model.VideoContentInfo
 class EpisodeMediaContainer(mc: IMediaContainer) : MovieMediaContainer(mc) {
 
     override fun createVideos(): List<VideoContentInfo> {
+        videoList = mutableListOf()
         val videos = mc.videos ?: return emptyList()
         val baseUrl = factory.baseURL().orEmpty()
         var parentPosterURL: String? = null

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/model/impl/EpisodeMediaContainer.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/model/impl/EpisodeMediaContainer.kt
@@ -11,7 +11,6 @@ import us.nineworlds.serenity.core.model.VideoContentInfo
 class EpisodeMediaContainer(mc: IMediaContainer) : MovieMediaContainer(mc) {
 
     override fun createVideos(): List<VideoContentInfo> {
-        videoList = mutableListOf()
         val videos = mc.videos ?: return emptyList()
         val baseUrl = factory.baseURL().orEmpty()
         var parentPosterURL: String? = null

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/model/impl/EpisodeMediaContainer.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/model/impl/EpisodeMediaContainer.kt
@@ -1,28 +1,34 @@
 package us.nineworlds.serenity.core.model.impl
 
-import android.content.res.Resources
-import javax.inject.Inject
-import toothpick.Toothpick
-import us.nineworlds.serenity.common.annotations.InjectionConstants
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
 import us.nineworlds.serenity.common.media.model.IMediaContainer
 import us.nineworlds.serenity.common.media.model.IVideo
 import us.nineworlds.serenity.core.model.VideoContentInfo
 
-@Suppress("Injectable")
 class EpisodeMediaContainer(mc: IMediaContainer) : MovieMediaContainer(mc) {
 
-    override fun createVideoContent(mc: IMediaContainer) {
+    override fun createVideos(): List<VideoContentInfo> {
+        val videos = mc.videos ?: return emptyList()
         val baseUrl = factory.baseURL().orEmpty()
         var parentPosterURL: String? = null
         if (!mc.parentPosterURL.isNullOrEmpty() && !mc.parentPosterURL.contains("show")) {
             parentPosterURL = baseUrl + mc.parentPosterURL.substring(1)
         }
-        val videos = mc.videos
-        if (videos != null) {
-            for (episode in videos) {
-                videoList!!.add(createEpisodeContentInfo(mc, baseUrl, parentPosterURL, episode))
-            }
+
+        val createdVideos = runBlocking {
+            videos.chunked(25).map { chunk ->
+                async(Dispatchers.Default) {
+                    chunk.map { episode ->
+                        createEpisodeContentInfo(mc, baseUrl, parentPosterURL, episode)
+                    }
+                }
+            }.awaitAll().flatten()
         }
+        videoList = createdVideos.toMutableList()
+        return createdVideos
     }
 
     private fun createEpisodeContentInfo(mc: IMediaContainer, baseUrl: String, parentPosterURL: String?, episode: IVideo): EpisodePosterInfo {

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/model/impl/MovieMediaContainer.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/model/impl/MovieMediaContainer.kt
@@ -1,5 +1,9 @@
 package us.nineworlds.serenity.core.model.impl
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
 import us.nineworlds.serenity.common.media.model.IMediaContainer
 import us.nineworlds.serenity.common.media.model.IVideo
 import us.nineworlds.serenity.common.rest.Types
@@ -7,62 +11,60 @@ import us.nineworlds.serenity.core.model.VideoContentInfo
 
 open class MovieMediaContainer(mc: IMediaContainer) : AbstractMediaContainer(mc) {
 
-    fun createVideos(): List<VideoContentInfo> {
-        videoList = mutableListOf()
-        createVideoContent(mc)
-        return videoList as List<VideoContentInfo>
-    }
-
-    protected open fun createVideoContent(mc: IMediaContainer) {
+    open fun createVideos(): List<VideoContentInfo> {
+        val videos = mc.videos ?: return emptyList()
         val baseUrl = factory.baseURL()
-        val videos = mc.videos ?: return
-
         val mediaTagId = mc.mediaTagVersion.toString()
         val baseImageResource = "$baseUrl:/resources/movie-fanart.jpg"
 
-        for (movie in videos) {
-            val mpi = MoviePosterInfo().apply {
-                setType(
-                    when (movie.type?.lowercase()) {
-                        "episode" -> Types.EPISODE.also { seriesName = movie.seriesName }
-                        "series" -> Types.SERIES.also { seriesName = movie.seriesName }
-                        "season" -> Types.SEASON.also { seriesName = movie.seriesName }
-                        "movie" -> Types.MOVIES
-                        else -> Types.UNKNOWN
-                    }
-                )
+        return runBlocking {
+            videos.chunked(25).map { chunk ->
+                async(Dispatchers.Default) {
+                    chunk.map { movie ->
+                        val mpi = MoviePosterInfo().apply {
+                            setType(
+                                when (movie.type?.lowercase()) {
+                                    "episode" -> Types.EPISODE.also { seriesName = movie.seriesName }
+                                    "series" -> Types.SERIES.also { seriesName = movie.seriesName }
+                                    "season" -> Types.SEASON.also { seriesName = movie.seriesName }
+                                    "movie" -> Types.MOVIES
+                                    else -> Types.UNKNOWN
+                                }
+                            )
 
-                setMediaTagIdentifier(mediaTagId)
-                setId(movie.key)
-                studio = movie.studio
-                setSummary(movie.summary)
-                resumeOffset = movie.viewOffset.toInt()
-                duration = movie.duration.toInt()
-                viewCount = movie.viewCount
-                rating = movie.rating
-                tagLine = movie.tagLine
-                setBackgroundURL(movie.backgroundImageKey?.let { "$baseUrl${it.replaceFirst("/", "")}" } ?: baseImageResource)
-                setImageURL(movie.thumbNailImageKey?.let { "$baseUrl${it.replaceFirst("/", "")}" } ?: "")
-                setTitle(movie.title)
-                contentRating = movie.contentRating
-                directPlayUrl = "$baseUrl${movie.directPlayUrl}"
+                            setMediaTagIdentifier(mediaTagId)
+                            setId(movie.key)
+                            studio = movie.studio
+                            setSummary(movie.summary)
+                            resumeOffset = movie.viewOffset.toInt()
+                            duration = movie.duration.toInt()
+                            viewCount = movie.viewCount
+                            rating = movie.rating
+                            tagLine = movie.tagLine
+                            setBackgroundURL(movie.backgroundImageKey?.let { "$baseUrl${it.replaceFirst("/", "")}" } ?: baseImageResource)
+                            setImageURL(movie.thumbNailImageKey?.let { "$baseUrl${it.replaceFirst("/", "")}" } ?: "")
+                            setTitle(movie.title)
+                            contentRating = movie.contentRating
+                            directPlayUrl = "$baseUrl${movie.directPlayUrl}"
 
-                val sortedMedias = movie.medias?.sortedByDescending { isDirectPlaySupported(it) }
-                sortedMedias?.firstOrNull()?.let { media ->
-                    container = media.container
-                    media.videoPart?.firstOrNull()?.let {
-                        directPlayUrl = "$baseUrl${it.key.replaceFirst("/", "")}"
+                            val sortedMedias = movie.medias?.sortedByDescending { isDirectPlaySupported(it) }
+                            sortedMedias?.firstOrNull()?.let { media ->
+                                container = media.container
+                                media.videoPart?.firstOrNull()?.let {
+                                    directPlayUrl = "$baseUrl${it.key.replaceFirst("/", "")}"
+                                }
+                                audioCodec = media.audioCodec
+                                videoCodec = media.videoCodec
+                                videoResolution = media.videoResolution
+                                aspectRatio = media.aspectRatio
+                                audioChannels = media.audioChannels
+                            }
+                        }
+                        createVideoDetails(movie, mpi)
+                        mpi
                     }
-                    audioCodec = media.audioCodec
-                    videoCodec = media.videoCodec
-                    videoResolution = media.videoResolution
-                    aspectRatio = media.aspectRatio
-                    audioChannels = media.audioChannels
                 }
-            }
-
-            createVideoDetails(movie, mpi)
-            videoList!!.add(mpi)
+            }.awaitAll().flatten()
         }
     }
 

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/EpisodePagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/EpisodePagingSource.kt
@@ -24,7 +24,8 @@ class EpisodePagingSource(private val repository: VideoRepository, private val i
     }
 
     override fun getRefreshKey(state: PagingState<Int, VideoContentInfo>): Int? = state.anchorPosition?.let { anchorPosition ->
-        state.closestPageToPosition(anchorPosition)?.prevKey?.plus(state.config.pageSize)
-            ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(state.config.pageSize)
+        state.closestPageToPosition(anchorPosition)?.run {
+            prevKey?.plus(state.config.pageSize) ?: nextKey?.minus(state.config.pageSize)
+        }
     }
 }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/EpisodePagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/EpisodePagingSource.kt
@@ -1,0 +1,35 @@
+package us.nineworlds.serenity.core.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import us.nineworlds.serenity.core.model.VideoContentInfo
+import us.nineworlds.serenity.core.repository.VideoRepository
+
+class EpisodePagingSource(
+    private val repository: VideoRepository,
+    private val itemId: String
+) : PagingSource<Int, VideoContentInfo>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, VideoContentInfo> {
+        val position = params.key ?: 0
+        val loadSize = params.loadSize
+
+        return try {
+            val data = repository.fetchEpisodes(itemId, position, loadSize)
+            LoadResult.Page(
+                data = data,
+                prevKey = if (position == 0) null else position - loadSize,
+                nextKey = if (data.isEmpty() || data.size < loadSize) null else position + data.size
+            )
+        } catch (ex: Exception) {
+            LoadResult.Error(ex)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, VideoContentInfo>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(state.config.pageSize)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(state.config.pageSize)
+        }
+    }
+}

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/EpisodePagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/EpisodePagingSource.kt
@@ -15,7 +15,7 @@ class EpisodePagingSource(private val repository: VideoRepository, private val i
             val data = repository.fetchEpisodes(itemId, position, loadSize)
             LoadResult.Page(
                 data = data,
-                prevKey = if (position == 0) null else position - loadSize,
+                prevKey = if (position == 0) null else maxOf(0, position - loadSize),
                 nextKey = if (data.isEmpty() || data.size < loadSize) null else position + data.size
             )
         } catch (ex: Exception) {

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/EpisodePagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/EpisodePagingSource.kt
@@ -5,10 +5,7 @@ import androidx.paging.PagingState
 import us.nineworlds.serenity.core.model.VideoContentInfo
 import us.nineworlds.serenity.core.repository.VideoRepository
 
-class EpisodePagingSource(
-    private val repository: VideoRepository,
-    private val itemId: String
-) : PagingSource<Int, VideoContentInfo>() {
+class EpisodePagingSource(private val repository: VideoRepository, private val itemId: String) : PagingSource<Int, VideoContentInfo>() {
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, VideoContentInfo> {
         val position = params.key ?: 0
@@ -26,10 +23,8 @@ class EpisodePagingSource(
         }
     }
 
-    override fun getRefreshKey(state: PagingState<Int, VideoContentInfo>): Int? {
-        return state.anchorPosition?.let { anchorPosition ->
-            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(state.config.pageSize)
-                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(state.config.pageSize)
-        }
+    override fun getRefreshKey(state: PagingState<Int, VideoContentInfo>): Int? = state.anchorPosition?.let { anchorPosition ->
+        state.closestPageToPosition(anchorPosition)?.prevKey?.plus(state.config.pageSize)
+            ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(state.config.pageSize)
     }
 }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSource.kt
@@ -17,7 +17,8 @@ class SimilarItemsPagingSource(private val repository: VideoRepository, private 
             LoadResult.Page(
                 data = data,
                 prevKey = if (position == 0) null else position - loadSize,
-                nextKey = if (data.isEmpty() || data.size < loadSize) null else position + loadSize            )
+                nextKey = if (data.isEmpty() || data.size < loadSize) null else position + data.size
+            )
         } catch (ex: Exception) {
             LoadResult.Error(ex)
         }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSource.kt
@@ -25,7 +25,8 @@ class SimilarItemsPagingSource(private val repository: VideoRepository, private 
     }
 
     override fun getRefreshKey(state: PagingState<Int, VideoContentInfo>): Int? = state.anchorPosition?.let { anchorPosition ->
-        state.closestPageToPosition(anchorPosition)?.prevKey?.plus(state.config.pageSize)
-            ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(state.config.pageSize)
+        state.closestPageToPosition(anchorPosition)?.run {
+            prevKey?.plus(state.config.pageSize) ?: nextKey?.minus(state.config.pageSize)
+        }
     }
 }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSource.kt
@@ -6,11 +6,7 @@ import us.nineworlds.serenity.common.rest.Types
 import us.nineworlds.serenity.core.model.VideoContentInfo
 import us.nineworlds.serenity.core.repository.VideoRepository
 
-class SimilarItemsPagingSource(
-    private val repository: VideoRepository,
-    private val itemId: String,
-    private val type: Types
-) : PagingSource<Int, VideoContentInfo>() {
+class SimilarItemsPagingSource(private val repository: VideoRepository, private val itemId: String, private val type: Types) : PagingSource<Int, VideoContentInfo>() {
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, VideoContentInfo> {
         val position = params.key ?: 0
@@ -28,10 +24,8 @@ class SimilarItemsPagingSource(
         }
     }
 
-    override fun getRefreshKey(state: PagingState<Int, VideoContentInfo>): Int? {
-        return state.anchorPosition?.let { anchorPosition ->
-            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(state.config.pageSize)
-                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(state.config.pageSize)
-        }
+    override fun getRefreshKey(state: PagingState<Int, VideoContentInfo>): Int? = state.anchorPosition?.let { anchorPosition ->
+        state.closestPageToPosition(anchorPosition)?.prevKey?.plus(state.config.pageSize)
+            ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(state.config.pageSize)
     }
 }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSource.kt
@@ -16,7 +16,7 @@ class SimilarItemsPagingSource(private val repository: VideoRepository, private 
             val data = repository.fetchSimilarItemsList(itemId, type, position, loadSize)
             LoadResult.Page(
                 data = data,
-                prevKey = if (position == 0) null else position - loadSize,
+                prevKey = if (position == 0) null else maxOf(0, position - loadSize),
                 nextKey = if (data.isEmpty() || data.size < loadSize) null else position + data.size
             )
         } catch (ex: Exception) {

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSource.kt
@@ -17,8 +17,7 @@ class SimilarItemsPagingSource(private val repository: VideoRepository, private 
             LoadResult.Page(
                 data = data,
                 prevKey = if (position == 0) null else position - loadSize,
-                nextKey = if (data.isEmpty() || data.size < loadSize) null else position + data.size
-            )
+                nextKey = if (data.isEmpty() || data.size < loadSize) null else position + loadSize            )
         } catch (ex: Exception) {
             LoadResult.Error(ex)
         }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSource.kt
@@ -1,0 +1,37 @@
+package us.nineworlds.serenity.core.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import us.nineworlds.serenity.common.rest.Types
+import us.nineworlds.serenity.core.model.VideoContentInfo
+import us.nineworlds.serenity.core.repository.VideoRepository
+
+class SimilarItemsPagingSource(
+    private val repository: VideoRepository,
+    private val itemId: String,
+    private val type: Types
+) : PagingSource<Int, VideoContentInfo>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, VideoContentInfo> {
+        val position = params.key ?: 0
+        val loadSize = params.loadSize
+
+        return try {
+            val data = repository.fetchSimilarItemsList(itemId, type, position, loadSize)
+            LoadResult.Page(
+                data = data,
+                prevKey = if (position == 0) null else position - loadSize,
+                nextKey = if (data.isEmpty() || data.size < loadSize) null else position + data.size
+            )
+        } catch (ex: Exception) {
+            LoadResult.Error(ex)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, VideoContentInfo>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(state.config.pageSize)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(state.config.pageSize)
+        }
+    }
+}

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/VideoCategoryPagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/VideoCategoryPagingSource.kt
@@ -16,11 +16,6 @@ class VideoCategoryPagingSource(private val repository: CategoryRepository, priv
         return when (val result = repository.fetchItemsByCategory(categoryId, itemId, type, position, loadSize)) {
             is Result.Success -> {
                 val data = result.data
-                LoadResult.Page(
-                    data = data,
-                    prevKey = if (position == 0) null else position - loadSize,
-                    nextKey = if (data.isEmpty() || data.size < loadSize) null else position + data.size
-                )
             }
 
             is Result.Error -> LoadResult.Error(result.exception)

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/VideoCategoryPagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/VideoCategoryPagingSource.kt
@@ -16,6 +16,11 @@ class VideoCategoryPagingSource(private val repository: CategoryRepository, priv
         return when (val result = repository.fetchItemsByCategory(categoryId, itemId, type, position, loadSize)) {
             is Result.Success -> {
                 val data = result.data
+                LoadResult.Page(
+                    data = data,
+                    prevKey = if (position <= 0) null else maxOf(0, position - loadSize),
+                    nextKey = if (data.isEmpty() || data.size < loadSize) null else position + data.size
+                )
             }
 
             is Result.Error -> LoadResult.Error(result.exception)

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/VideoCategoryPagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/VideoCategoryPagingSource.kt
@@ -1,0 +1,39 @@
+package us.nineworlds.serenity.core.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import us.nineworlds.serenity.common.repository.Result
+import us.nineworlds.serenity.core.model.VideoContentInfo
+import us.nineworlds.serenity.core.repository.CategoryRepository
+
+class VideoCategoryPagingSource(
+    private val repository: CategoryRepository,
+    private val categoryId: String,
+    private val itemId: String,
+    private val type: String
+) : PagingSource<Int, VideoContentInfo>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, VideoContentInfo> {
+        val position = params.key ?: 0
+        val loadSize = params.loadSize
+
+        return when (val result = repository.fetchItemsByCategory(categoryId, itemId, type, position, loadSize)) {
+            is Result.Success -> {
+                val data = result.data
+                LoadResult.Page(
+                    data = data,
+                    prevKey = if (position == 0) null else position - loadSize,
+                    nextKey = if (data.isEmpty() || data.size < loadSize) null else position + data.size
+                )
+            }
+            is Result.Error -> LoadResult.Error(result.exception)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, VideoContentInfo>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(state.config.pageSize)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(state.config.pageSize)
+        }
+    }
+}

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/VideoCategoryPagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/VideoCategoryPagingSource.kt
@@ -6,12 +6,8 @@ import us.nineworlds.serenity.common.repository.Result
 import us.nineworlds.serenity.core.model.VideoContentInfo
 import us.nineworlds.serenity.core.repository.CategoryRepository
 
-class VideoCategoryPagingSource(
-    private val repository: CategoryRepository,
-    private val categoryId: String,
-    private val itemId: String,
-    private val type: String
-) : PagingSource<Int, VideoContentInfo>() {
+class VideoCategoryPagingSource(private val repository: CategoryRepository, private val categoryId: String, private val itemId: String, private val type: String) :
+    PagingSource<Int, VideoContentInfo>() {
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, VideoContentInfo> {
         val position = params.key ?: 0
@@ -26,14 +22,13 @@ class VideoCategoryPagingSource(
                     nextKey = if (data.isEmpty() || data.size < loadSize) null else position + data.size
                 )
             }
+
             is Result.Error -> LoadResult.Error(result.exception)
         }
     }
 
-    override fun getRefreshKey(state: PagingState<Int, VideoContentInfo>): Int? {
-        return state.anchorPosition?.let { anchorPosition ->
-            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(state.config.pageSize)
-                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(state.config.pageSize)
-        }
+    override fun getRefreshKey(state: PagingState<Int, VideoContentInfo>): Int? = state.anchorPosition?.let { anchorPosition ->
+        state.closestPageToPosition(anchorPosition)?.prevKey?.plus(state.config.pageSize)
+            ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(state.config.pageSize)
     }
 }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/VideoCategoryPagingSource.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/paging/VideoCategoryPagingSource.kt
@@ -28,7 +28,8 @@ class VideoCategoryPagingSource(private val repository: CategoryRepository, priv
     }
 
     override fun getRefreshKey(state: PagingState<Int, VideoContentInfo>): Int? = state.anchorPosition?.let { anchorPosition ->
-        state.closestPageToPosition(anchorPosition)?.prevKey?.plus(state.config.pageSize)
-            ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(state.config.pageSize)
+        state.closestPageToPosition(anchorPosition)?.run {
+            prevKey?.plus(state.config.pageSize) ?: nextKey?.minus(state.config.pageSize)
+        }
     }
 }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/repository/CategoryRepository.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/repository/CategoryRepository.kt
@@ -48,13 +48,7 @@ class CategoryRepository constructor(private val client: SerenityClient) {
         private const val MENU_TYPE_TVSHOWS = "tvshows"
     }
 
-    suspend fun fetchItemsByCategory(
-        categoryId: String,
-        itemId: String,
-        type: String,
-        startIndex: Int = 0,
-        limit: Int? = null
-    ): Result<List<VideoContentInfo>> = withContext(Dispatchers.IO) {
+    suspend fun fetchItemsByCategory(categoryId: String, itemId: String, type: String, startIndex: Int = 0, limit: Int? = null): Result<List<VideoContentInfo>> = withContext(Dispatchers.IO) {
         try {
             val contentType = when (type) {
                 MENU_TYPE_MOVIE, MENU_TYPE_MOVIES -> Types.MOVIES

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/repository/CategoryRepository.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/repository/CategoryRepository.kt
@@ -48,14 +48,20 @@ class CategoryRepository constructor(private val client: SerenityClient) {
         private const val MENU_TYPE_TVSHOWS = "tvshows"
     }
 
-    suspend fun fetchItemsByCategory(categoryId: String, itemId: String, type: String): Result<List<VideoContentInfo>> = withContext(Dispatchers.IO) {
+    suspend fun fetchItemsByCategory(
+        categoryId: String,
+        itemId: String,
+        type: String,
+        startIndex: Int = 0,
+        limit: Int? = null
+    ): Result<List<VideoContentInfo>> = withContext(Dispatchers.IO) {
         try {
             val contentType = when (type) {
                 MENU_TYPE_MOVIE, MENU_TYPE_MOVIES -> Types.MOVIES
                 MENU_TYPE_SHOW, MENU_TYPE_TVSHOWS -> Types.SERIES
                 else -> Types.UNKNOWN
             }
-            val result = client.retrieveItemByIdCategory(itemId, categoryId, contentType)
+            val result = client.retrieveItemByIdCategory(itemId, categoryId, contentType, startIndex, limit)
 
             val movies = MovieMediaContainer(result)
             val posterList: List<VideoContentInfo> = movies.createVideos()

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/repository/VideoRepository.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/repository/VideoRepository.kt
@@ -21,30 +21,16 @@ class VideoRepository constructor(private val client: SerenityClient) {
         client.retrieveSeasons(itemId)
     }
 
-    suspend fun fetchEpisodes(
-        itemId: String,
-        startIndex: Int = 0,
-        limit: Int? = null
-    ): List<VideoContentInfo> = withContext(Dispatchers.IO) {
+    suspend fun fetchEpisodes(itemId: String, startIndex: Int = 0, limit: Int? = null): List<VideoContentInfo> = withContext(Dispatchers.IO) {
         val result = client.retrieveEpisodes(itemId, startIndex, limit)
         EpisodeMediaContainer(result).createVideos()
     }
 
-    suspend fun fetchSimilarItems(
-        itemId: String,
-        type: Types,
-        startIndex: Int = 0,
-        limit: Int? = null
-    ): IMediaContainer = withContext(Dispatchers.IO) {
+    suspend fun fetchSimilarItems(itemId: String, type: Types, startIndex: Int = 0, limit: Int? = null): IMediaContainer = withContext(Dispatchers.IO) {
         client.fetchSimilarItemById(itemId, type, startIndex, limit)
     }
 
-    suspend fun fetchSimilarItemsList(
-        itemId: String,
-        type: Types,
-        startIndex: Int = 0,
-        limit: Int? = null
-    ): List<VideoContentInfo> = withContext(Dispatchers.IO) {
+    suspend fun fetchSimilarItemsList(itemId: String, type: Types, startIndex: Int = 0, limit: Int? = null): List<VideoContentInfo> = withContext(Dispatchers.IO) {
         val result = client.fetchSimilarItemById(itemId, type, startIndex, limit)
         MovieMediaContainer(result).createVideos()
     }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/repository/VideoRepository.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/core/repository/VideoRepository.kt
@@ -8,6 +8,7 @@ import us.nineworlds.serenity.common.rest.SerenityClient
 import us.nineworlds.serenity.common.rest.Types
 import us.nineworlds.serenity.core.model.VideoContentInfo
 import us.nineworlds.serenity.core.model.impl.EpisodeMediaContainer
+import us.nineworlds.serenity.core.model.impl.MovieMediaContainer
 
 @InjectConstructor
 class VideoRepository constructor(private val client: SerenityClient) {
@@ -20,12 +21,31 @@ class VideoRepository constructor(private val client: SerenityClient) {
         client.retrieveSeasons(itemId)
     }
 
-    suspend fun fetchEpisodes(itemId: String): List<VideoContentInfo> = withContext(Dispatchers.IO) {
-        val result = client.retrieveEpisodes(itemId)
+    suspend fun fetchEpisodes(
+        itemId: String,
+        startIndex: Int = 0,
+        limit: Int? = null
+    ): List<VideoContentInfo> = withContext(Dispatchers.IO) {
+        val result = client.retrieveEpisodes(itemId, startIndex, limit)
         EpisodeMediaContainer(result).createVideos()
     }
 
-    suspend fun fetchSimilarItems(itemId: String, type: Types): IMediaContainer = withContext(Dispatchers.IO) {
-        client.fetchSimilarItemById(itemId, type)
+    suspend fun fetchSimilarItems(
+        itemId: String,
+        type: Types,
+        startIndex: Int = 0,
+        limit: Int? = null
+    ): IMediaContainer = withContext(Dispatchers.IO) {
+        client.fetchSimilarItemById(itemId, type, startIndex, limit)
+    }
+
+    suspend fun fetchSimilarItemsList(
+        itemId: String,
+        type: Types,
+        startIndex: Int = 0,
+        limit: Int? = null
+    ): List<VideoContentInfo> = withContext(Dispatchers.IO) {
+        val result = client.fetchSimilarItemById(itemId, type, startIndex, limit)
+        MovieMediaContainer(result).createVideos()
     }
 }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/fragments/mainmenu/MainMenuPresenter.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/fragments/mainmenu/MainMenuPresenter.kt
@@ -5,6 +5,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
 import androidx.paging.map
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
@@ -52,27 +53,26 @@ class MainMenuPresenter : MvpPresenter<MainMenuView>() {
     }
 
     fun populateMovieCategories(itemId: String, type: String) {
-        galleryJob?.let { job ->
-            job.cancel()
-        }
+        galleryJob?.cancel()
         viewState.showLoading()
         galleryJob = presenterScope.launch {
             when (val result = repository.retrieveCategories(itemId)) {
                 is Result.Success -> {
-                    processesCategories(result.data, itemId, type)
+                    processesCategories(this, result.data, itemId, type)
                 }
 
                 else -> {}
             }
+            viewState.hideLoading()
         }
     }
 
-    private suspend fun processesCategories(categories: List<CategoryInfo>, itemId: String, type: String) {
+    private fun processesCategories(scope: CoroutineScope, categories: List<CategoryInfo>, itemId: String, type: String) {
         if (type == "movies" || type == "tv show" || type == "tvshows") {
             val filteredCategories = categories.filter { category -> category.category != "unwatched" }
             val categoryVideoContentInfo = CategoryVideoInfo(categories = filteredCategories)
 
-            withContext(Dispatchers.Main) {
+            scope.launch(Dispatchers.Main) {
                 viewState.loadCategories(categoryVideoContentInfo)
             }
 
@@ -81,7 +81,8 @@ class MainMenuPresenter : MvpPresenter<MainMenuView>() {
                     config = PagingConfig(
                         pageSize = 8,
                         initialLoadSize = 10,
-                        enablePlaceholders = false
+                        enablePlaceholders = false,
+                        prefetchDistance = 4
                     ),
                     pagingSourceFactory = {
                         VideoCategoryPagingSource(
@@ -100,25 +101,24 @@ class MainMenuPresenter : MvpPresenter<MainMenuView>() {
                             )
                         }
                     }
-                    .cachedIn(presenterScope)
+                    .cachedIn(scope)
 
-                presenterScope.launch {
+                scope.launch {
                     pagingFlow.collectLatest { pagingData ->
                         viewState.updateCategories(category, pagingData)
                     }
                 }
             }
         } else {
-            withContext(Dispatchers.Main) {
+            scope.launch(Dispatchers.Main) {
                 viewState.clearCategories()
             }
         }
-        viewState.hideLoading()
     }
 
     private fun getType(type: String): Types = when (type) {
         "movies", "movie" -> Types.MOVIES
-        "tvshows" -> Types.SERIES
+        "tvshows", "tv show" -> Types.SERIES
         else -> Types.UNKNOWN
     }
 }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/fragments/mainmenu/MainMenuPresenter.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/fragments/mainmenu/MainMenuPresenter.kt
@@ -1,9 +1,14 @@
 package us.nineworlds.serenity.fragments.mainmenu
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.cachedIn
+import androidx.paging.map
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moxy.InjectViewState
@@ -18,6 +23,7 @@ import us.nineworlds.serenity.common.rest.Types
 import us.nineworlds.serenity.core.model.CategoryInfo
 import us.nineworlds.serenity.core.model.CategoryVideoInfo
 import us.nineworlds.serenity.core.model.VideoCategory
+import us.nineworlds.serenity.core.paging.VideoCategoryPagingSource
 import us.nineworlds.serenity.core.repository.CategoryRepository
 
 @InjectViewState
@@ -69,24 +75,36 @@ class MainMenuPresenter : MvpPresenter<MainMenuView>() {
             withContext(Dispatchers.Main) {
                 viewState.loadCategories(categoryVideoContentInfo)
             }
-            coroutineScope {
-                filteredCategories.forEach { category ->
-                    launch {
-                        when (val result = repository.fetchItemsByCategory(category.category.orEmpty(), itemId, type)) {
-                            is Result.Success -> {
-                                withContext(Dispatchers.Main) {
-                                    val videos = result.data.map { videoContentInfo ->
-                                        VideoCategory(
-                                            type = getType(type),
-                                            item = videoContentInfo
-                                        )
-                                    }
-                                    viewState.updateCategories(category, videos)
-                                }
-                            }
 
-                            else -> {}
+            filteredCategories.forEach { category ->
+                val pagingFlow = Pager(
+                    config = PagingConfig(
+                        pageSize = 8,
+                        initialLoadSize = 10,
+                        enablePlaceholders = false
+                    ),
+                    pagingSourceFactory = {
+                        VideoCategoryPagingSource(
+                            repository,
+                            category.category.orEmpty(),
+                            itemId,
+                            type
+                        )
+                    }
+                ).flow
+                    .map { pagingData ->
+                        pagingData.map { videoContentInfo ->
+                            VideoCategory(
+                                type = getType(type),
+                                item = videoContentInfo
+                            )
                         }
+                    }
+                    .cachedIn(presenterScope)
+
+                presenterScope.launch {
+                    pagingFlow.collectLatest { pagingData ->
+                        viewState.updateCategories(category, pagingData)
                     }
                 }
             }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/fragments/mainmenu/MainMenuPresenter.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/fragments/mainmenu/MainMenuPresenter.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import moxy.InjectViewState
 import moxy.MvpPresenter
 import moxy.presenterScope

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/fragments/mainmenu/MainMenuView.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/fragments/mainmenu/MainMenuView.kt
@@ -1,7 +1,9 @@
 package us.nineworlds.serenity.fragments.mainmenu
 
+import androidx.paging.PagingData
 import moxy.MvpView
 import moxy.viewstate.strategy.AddToEndSingleStrategy
+import moxy.viewstate.strategy.AddToEndStrategy
 import moxy.viewstate.strategy.StateStrategyType
 import us.nineworlds.serenity.core.model.CategoryInfo
 import us.nineworlds.serenity.core.model.CategoryVideoInfo
@@ -16,8 +18,8 @@ interface MainMenuView : MvpView {
     @StateStrategyType(AddToEndSingleStrategy::class)
     fun loadCategories(videoCategories: CategoryVideoInfo)
 
-    @StateStrategyType(AddToEndSingleStrategy::class)
-    fun updateCategories(category: CategoryInfo, items: List<VideoCategory>)
+    @StateStrategyType(AddToEndStrategy::class)
+    fun updateCategories(category: CategoryInfo, pagingData: PagingData<VideoCategory>)
 
     @StateStrategyType(AddToEndSingleStrategy::class)
     fun clearCategories()

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsFragment.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsFragment.kt
@@ -60,11 +60,9 @@ class DetailsFragment :
     private lateinit var mvpDelegate: MvpDelegate<out DetailsFragment>
 
     private val videoContentDiffCallback = object : DiffUtil.ItemCallback<VideoContentInfo>() {
-        override fun areItemsTheSame(oldItem: VideoContentInfo, newItem: VideoContentInfo): Boolean =
-            oldItem.id() == newItem.id()
+        override fun areItemsTheSame(oldItem: VideoContentInfo, newItem: VideoContentInfo): Boolean = oldItem.id() == newItem.id()
 
-        override fun areContentsTheSame(oldItem: VideoContentInfo, newItem: VideoContentInfo): Boolean =
-            oldItem == newItem
+        override fun areContentsTheSame(oldItem: VideoContentInfo, newItem: VideoContentInfo): Boolean = oldItem == newItem
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsFragment.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsFragment.kt
@@ -20,6 +20,7 @@ import androidx.recyclerview.widget.DiffUtil
 import com.bumptech.glide.Glide
 import javax.inject.Inject
 import javax.inject.Provider
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import moxy.MvpDelegate
 import moxy.MvpDelegateHolder
@@ -64,6 +65,9 @@ class DetailsFragment :
 
         override fun areContentsTheSame(oldItem: VideoContentInfo, newItem: VideoContentInfo): Boolean = oldItem == newItem
     }
+
+    private var seasonEpisodesJob: Job? = null
+    private var similarItemsJob: Job? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -245,7 +249,8 @@ class DetailsFragment :
             .filter { listRow -> listRow.headerItem.name == season.getTitle() }
             .forEach { row ->
                 val adapter = row.adapter as SerenityPagingDataAdapter<VideoContentInfo>
-                viewLifecycleOwner.lifecycleScope.launch {
+                seasonEpisodesJob?.cancel()
+                seasonEpisodesJob = viewLifecycleOwner.lifecycleScope.launch {
                     adapter.submitData(pagingData)
                 }
             }
@@ -261,7 +266,8 @@ class DetailsFragment :
         val detailsAdapter = adapter as ArrayObjectAdapter
         detailsAdapter.add(similarRow)
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        similarItemsJob?.cancel()
+        similarItemsJob = viewLifecycleOwner.lifecycleScope.launch {
             itemsAdapter.submitData(pagingData)
         }
     }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsFragment.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsFragment.kt
@@ -20,7 +20,6 @@ import androidx.recyclerview.widget.DiffUtil
 import com.bumptech.glide.Glide
 import javax.inject.Inject
 import javax.inject.Provider
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import moxy.MvpDelegate
 import moxy.MvpDelegateHolder
@@ -65,9 +64,6 @@ class DetailsFragment :
 
         override fun areContentsTheSame(oldItem: VideoContentInfo, newItem: VideoContentInfo): Boolean = oldItem == newItem
     }
-
-    private var seasonEpisodesJob: Job? = null
-    private var similarItemsJob: Job? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -249,8 +245,7 @@ class DetailsFragment :
             .filter { listRow -> listRow.headerItem.name == season.getTitle() }
             .forEach { row ->
                 val adapter = row.adapter as SerenityPagingDataAdapter<VideoContentInfo>
-                seasonEpisodesJob?.cancel()
-                seasonEpisodesJob = viewLifecycleOwner.lifecycleScope.launch {
+                viewLifecycleOwner.lifecycleScope.launch {
                     adapter.submitData(pagingData)
                 }
             }
@@ -266,8 +261,7 @@ class DetailsFragment :
         val detailsAdapter = adapter as ArrayObjectAdapter
         detailsAdapter.add(similarRow)
 
-        similarItemsJob?.cancel()
-        similarItemsJob = viewLifecycleOwner.lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             itemsAdapter.submitData(pagingData)
         }
     }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsFragment.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsFragment.kt
@@ -8,16 +8,19 @@ import androidx.leanback.app.DetailsSupportFragment
 import androidx.leanback.widget.Action
 import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.ClassPresenterSelector
-import androidx.leanback.widget.DiffCallback
 import androidx.leanback.widget.HeaderItem
 import androidx.leanback.widget.ListRow
 import androidx.leanback.widget.ListRowPresenter
 import androidx.leanback.widget.Presenter
 import androidx.leanback.widget.Row
 import androidx.leanback.widget.SparseArrayObjectAdapter
+import androidx.lifecycle.lifecycleScope
+import androidx.paging.PagingData
+import androidx.recyclerview.widget.DiffUtil
 import com.bumptech.glide.Glide
 import javax.inject.Inject
 import javax.inject.Provider
+import kotlinx.coroutines.launch
 import moxy.MvpDelegate
 import moxy.MvpDelegateHolder
 import moxy.ktx.moxyPresenter
@@ -29,6 +32,8 @@ import us.nineworlds.serenity.core.model.SeriesContentInfo
 import us.nineworlds.serenity.core.model.VideoContentInfo
 import us.nineworlds.serenity.core.model.impl.EpisodePosterInfo
 import us.nineworlds.serenity.core.model.impl.TVShowSeriesInfo
+import us.nineworlds.serenity.ui.activity.leanback.details.DetailsActivity
+import us.nineworlds.serenity.ui.leanback.adapters.SerenityPagingDataAdapter
 import us.nineworlds.serenity.ui.leanback.presenters.DetailsOverviewRow
 import us.nineworlds.serenity.ui.leanback.presenters.EpisodeVideoPresenter
 import us.nineworlds.serenity.ui.leanback.presenters.FullWidthDetailsOverviewRowPresenter
@@ -53,6 +58,14 @@ class DetailsFragment :
     private var stateSaved = false
 
     private lateinit var mvpDelegate: MvpDelegate<out DetailsFragment>
+
+    private val videoContentDiffCallback = object : DiffUtil.ItemCallback<VideoContentInfo>() {
+        override fun areItemsTheSame(oldItem: VideoContentInfo, newItem: VideoContentInfo): Boolean =
+            oldItem.id() == newItem.id()
+
+        override fun areContentsTheSame(oldItem: VideoContentInfo, newItem: VideoContentInfo): Boolean =
+            oldItem == newItem
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -217,8 +230,7 @@ class DetailsFragment :
     override fun addSeasons(videoInfo: List<SeriesContentInfo>) {
         videoInfo.forEach { season ->
             classPresenterSelector.addClassPresenter(ListRow::class.java, ListRowPresenter())
-            val seasonAdapter = ArrayObjectAdapter(EpisodeVideoPresenter())
-            seasonAdapter.addAll(0, emptyList<VideoContentInfo>())
+            val seasonAdapter = SerenityPagingDataAdapter(EpisodeVideoPresenter(), videoContentDiffCallback)
 
             val seasonHeader = HeaderItem(season.getTitle())
             val seasonRow = ListRow(seasonHeader, seasonAdapter)
@@ -228,36 +240,32 @@ class DetailsFragment :
         }
     }
 
-    override fun updateSeasonEpisodes(season: SeriesContentInfo, episodes: List<VideoContentInfo>) {
+    override fun updateSeasonEpisodes(season: SeriesContentInfo, pagingData: PagingData<VideoContentInfo>) {
         val detailsAdapter = adapter as ArrayObjectAdapter
         val content = detailsAdapter.unmodifiableList<Row>()
         content.filterIsInstance<ListRow>()
             .filter { listRow -> listRow.headerItem.name == season.getTitle() }
             .forEach { row ->
-                val adapter = row.adapter as ArrayObjectAdapter
-                adapter.setItems(
-                    episodes,
-                    object : DiffCallback<VideoContentInfo>() {
-                        override fun areItemsTheSame(oldItem: VideoContentInfo, newItem: VideoContentInfo): Boolean = oldItem.season == newItem.season &&
-                            oldItem.seasonNumber == newItem.seasonNumber &&
-                            oldItem.parentKey == newItem.parentKey
-
-                        override fun areContentsTheSame(oldItem: VideoContentInfo, newItem: VideoContentInfo): Boolean = oldItem == newItem
-                    }
-                )
+                val adapter = row.adapter as SerenityPagingDataAdapter<VideoContentInfo>
+                viewLifecycleOwner.lifecycleScope.launch {
+                    adapter.submitData(pagingData)
+                }
             }
     }
 
-    override fun addSimilarItems(videoInfo: List<VideoContentInfo>) {
+    override fun addSimilarItems(pagingData: PagingData<VideoContentInfo>) {
         classPresenterSelector.addClassPresenter(ListRow::class.java, ListRowPresenter())
-        val itemsAdapter = ArrayObjectAdapter(VideoContentInfoPresenter())
+        val itemsAdapter = SerenityPagingDataAdapter(VideoContentInfoPresenter(), videoContentDiffCallback)
 
         val header = HeaderItem("Similar")
-        itemsAdapter.addAll(0, videoInfo)
         val similarRow = ListRow(header, itemsAdapter)
 
         val detailsAdapter = adapter as ArrayObjectAdapter
         detailsAdapter.add(similarRow)
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            itemsAdapter.submitData(pagingData)
+        }
     }
 
     override fun addSimilarSeries(videoInfo: List<SeriesContentInfo>) {

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsMVPPresenter.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsMVPPresenter.kt
@@ -91,6 +91,9 @@ class DetailsMVPPresenter : MvpPresenter<DetailsView>() {
         }
 
         seasons.forEach { season ->
+            val seasonsKey = season.key
+            if (seasonsKey.isNullOrEmpty()) return@forEach
+
             val pagingFlow = Pager(
                 config = PagingConfig(
                     pageSize = 15,
@@ -98,7 +101,7 @@ class DetailsMVPPresenter : MvpPresenter<DetailsView>() {
                     enablePlaceholders = false
                 ),
                 pagingSourceFactory = {
-                    EpisodePagingSource(repository, season.key.orEmpty())
+                    EpisodePagingSource(repository, seasonsKey)
                 }
             ).flow
                 .cachedIn(presenterScope)

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsMVPPresenter.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsMVPPresenter.kt
@@ -1,8 +1,13 @@
 package us.nineworlds.serenity.ui.activity.leanback.details
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.cachedIn
+import androidx.paging.filter
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moxy.MvpPresenter
@@ -13,6 +18,8 @@ import us.nineworlds.serenity.common.rest.Types
 import us.nineworlds.serenity.core.model.impl.MovieMediaContainer
 import us.nineworlds.serenity.core.model.impl.SeasonsMediaContainer
 import us.nineworlds.serenity.core.model.impl.SeriesMediaContainer
+import us.nineworlds.serenity.core.paging.EpisodePagingSource
+import us.nineworlds.serenity.core.paging.SimilarItemsPagingSource
 import us.nineworlds.serenity.core.repository.VideoRepository
 
 class DetailsMVPPresenter : MvpPresenter<DetailsView>() {
@@ -42,25 +49,36 @@ class DetailsMVPPresenter : MvpPresenter<DetailsView>() {
     }
 
     fun loadSimilarItems(itemId: String, type: String) {
-        presenterScope.launch {
-            val itemType = when (type) {
-                "tvshows" -> Types.SERIES
-                else -> Types.MOVIES
-            }
+        val itemType = when (type) {
+            "tvshows" -> Types.SERIES
+            else -> Types.MOVIES
+        }
 
-            val result = repository.fetchSimilarItems(itemId, itemType)
-            when (itemType) {
-                Types.MOVIES -> {
-                    val videos = MovieMediaContainer(result)
-                        .createVideos()
-                        .filterNot { item ->
-                            item.getType() == Types.SERIES
-                        }
-
-                    viewState.addSimilarItems(videos)
+        if (itemType == Types.MOVIES) {
+            val pagingFlow = Pager(
+                config = PagingConfig(
+                    pageSize = 15,
+                    initialLoadSize = 30,
+                    enablePlaceholders = false
+                ),
+                pagingSourceFactory = {
+                    SimilarItemsPagingSource(repository, itemId, itemType)
                 }
+            ).flow
+                .map { pagingData ->
+                    pagingData.filter { item -> item.getType() != Types.SERIES }
+                }
+                .cachedIn(presenterScope)
 
-                else -> viewState.addSimilarSeries(SeriesMediaContainer(result).createSeries())
+            presenterScope.launch {
+                pagingFlow.collectLatest { pagingData ->
+                    viewState.addSimilarItems(pagingData)
+                }
+            }
+        } else {
+            presenterScope.launch {
+                val result = repository.fetchSimilarItems(itemId, itemType)
+                viewState.addSimilarSeries(SeriesMediaContainer(result).createSeries())
             }
         }
     }
@@ -71,13 +89,23 @@ class DetailsMVPPresenter : MvpPresenter<DetailsView>() {
         withContext(Dispatchers.Main) {
             viewState.addSeasons(seasons)
         }
-        presenterScope.launch(Dispatchers.IO) {
-            seasons.forEach { season ->
-                async {
-                    val result = repository.fetchEpisodes(season.key.orEmpty())
-                    withContext(Dispatchers.Main) {
-                        viewState.updateSeasonEpisodes(season, result)
-                    }
+
+        seasons.forEach { season ->
+            val pagingFlow = Pager(
+                config = PagingConfig(
+                    pageSize = 15,
+                    initialLoadSize = 30,
+                    enablePlaceholders = false
+                ),
+                pagingSourceFactory = {
+                    EpisodePagingSource(repository, season.key.orEmpty())
+                }
+            ).flow
+                .cachedIn(presenterScope)
+
+            presenterScope.launch {
+                pagingFlow.collectLatest { pagingData ->
+                    viewState.updateSeasonEpisodes(season, pagingData)
                 }
             }
         }

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsMVPPresenter.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsMVPPresenter.kt
@@ -91,9 +91,6 @@ class DetailsMVPPresenter : MvpPresenter<DetailsView>() {
         }
 
         seasons.forEach { season ->
-            val seasonsKey = season.key
-            if (seasonsKey.isNullOrEmpty()) return@forEach
-
             val pagingFlow = Pager(
                 config = PagingConfig(
                     pageSize = 15,
@@ -101,7 +98,7 @@ class DetailsMVPPresenter : MvpPresenter<DetailsView>() {
                     enablePlaceholders = false
                 ),
                 pagingSourceFactory = {
-                    EpisodePagingSource(repository, seasonsKey)
+                    EpisodePagingSource(repository, season.key.orEmpty())
                 }
             ).flow
                 .cachedIn(presenterScope)

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsView.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsView.kt
@@ -1,5 +1,6 @@
 package us.nineworlds.serenity.ui.activity.leanback.details
 
+import androidx.paging.PagingData
 import moxy.MvpView
 import moxy.viewstate.strategy.OneExecutionStateStrategy
 import moxy.viewstate.strategy.StateStrategyType
@@ -16,10 +17,10 @@ interface DetailsView : MvpView {
     fun addSeasons(videoInfo: List<SeriesContentInfo>)
 
     @StateStrategyType(OneExecutionStateStrategy::class)
-    fun updateSeasonEpisodes(season: SeriesContentInfo, episodes: List<VideoContentInfo>)
+    fun updateSeasonEpisodes(season: SeriesContentInfo, pagingData: PagingData<VideoContentInfo>)
 
     @StateStrategyType(OneExecutionStateStrategy::class)
-    fun addSimilarItems(videoInfo: List<VideoContentInfo>)
+    fun addSimilarItems(pagingData: PagingData<VideoContentInfo>)
 
     @StateStrategyType(OneExecutionStateStrategy::class)
     fun addSimilarSeries(videoInfo: List<SeriesContentInfo>)

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/leanback/adapters/SerenityPagingDataAdapter.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/leanback/adapters/SerenityPagingDataAdapter.kt
@@ -11,10 +11,7 @@ import androidx.recyclerview.widget.DiffUtil
  * A generic PagingDataAdapter for Serenity that integrates Paging 3 with Leanback.
  * This class wraps androidx.leanback.paging.PagingDataAdapter as it is final and cannot be inherited from.
  */
-class SerenityPagingDataAdapter<T : Any>(
-    presenterSelector: PresenterSelector,
-    diffCallback: DiffUtil.ItemCallback<T>
-) : ObjectAdapter(presenterSelector) {
+class SerenityPagingDataAdapter<T : Any>(presenterSelector: PresenterSelector, diffCallback: DiffUtil.ItemCallback<T>) : ObjectAdapter(presenterSelector) {
 
     private val internalAdapter = PagingDataAdapter(presenterSelector, diffCallback)
 
@@ -41,9 +38,12 @@ class SerenityPagingDataAdapter<T : Any>(
     }
 
     constructor(presenter: Presenter, diffCallback: DiffUtil.ItemCallback<T>) :
-            this(object : PresenterSelector() {
+        this(
+            object : PresenterSelector() {
                 override fun getPresenter(item: Any?): Presenter = presenter
-            }, diffCallback)
+            },
+            diffCallback
+        )
 
     override fun size(): Int = internalAdapter.size()
 

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/leanback/adapters/SerenityPagingDataAdapter.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/leanback/adapters/SerenityPagingDataAdapter.kt
@@ -1,0 +1,55 @@
+package us.nineworlds.serenity.ui.leanback.adapters
+
+import androidx.leanback.paging.PagingDataAdapter
+import androidx.leanback.widget.ObjectAdapter
+import androidx.leanback.widget.Presenter
+import androidx.leanback.widget.PresenterSelector
+import androidx.paging.PagingData
+import androidx.recyclerview.widget.DiffUtil
+
+/**
+ * A generic PagingDataAdapter for Serenity that integrates Paging 3 with Leanback.
+ * This class wraps androidx.leanback.paging.PagingDataAdapter as it is final and cannot be inherited from.
+ */
+class SerenityPagingDataAdapter<T : Any>(
+    presenterSelector: PresenterSelector,
+    diffCallback: DiffUtil.ItemCallback<T>
+) : ObjectAdapter(presenterSelector) {
+
+    private val internalAdapter = PagingDataAdapter(presenterSelector, diffCallback)
+
+    private val dataObserver = object : DataObserver() {
+        override fun onChanged() {
+            notifyChanged()
+        }
+
+        override fun onItemRangeChanged(positionStart: Int, itemCount: Int) {
+            notifyItemRangeChanged(positionStart, itemCount)
+        }
+
+        override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+            notifyItemRangeInserted(positionStart, itemCount)
+        }
+
+        override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+            notifyItemRangeRemoved(positionStart, itemCount)
+        }
+    }
+
+    init {
+        internalAdapter.registerObserver(dataObserver)
+    }
+
+    constructor(presenter: Presenter, diffCallback: DiffUtil.ItemCallback<T>) :
+            this(object : PresenterSelector() {
+                override fun getPresenter(item: Any?): Presenter = presenter
+            }, diffCallback)
+
+    override fun size(): Int = internalAdapter.size()
+
+    override fun get(position: Int): Any? = internalAdapter.get(position)
+
+    suspend fun submitData(pagingData: PagingData<T>) {
+        internalAdapter.submitData(pagingData)
+    }
+}

--- a/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/leanback/adapters/SerenityPagingDataAdapter.kt
+++ b/serenity-app/src/main/kotlin/us/nineworlds/serenity/ui/leanback/adapters/SerenityPagingDataAdapter.kt
@@ -47,7 +47,16 @@ class SerenityPagingDataAdapter<T : Any>(presenterSelector: PresenterSelector, d
 
     override fun size(): Int = internalAdapter.size()
 
-    override fun get(position: Int): Any? = internalAdapter.get(position)
+    override fun get(position: Int): Any? {
+        if (position < 0 || position >= size()) {
+            return null
+        }
+        return try {
+            internalAdapter.get(position)
+        } catch (e: IndexOutOfBoundsException) {
+            null
+        }
+    }
 
     suspend fun submitData(pagingData: PagingData<T>) {
         internalAdapter.submitData(pagingData)

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/core/paging/EpisodePagingSourceTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/core/paging/EpisodePagingSourceTest.kt
@@ -1,0 +1,112 @@
+package us.nineworlds.serenity.core.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNull
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import toothpick.config.Module
+import us.nineworlds.serenity.core.model.VideoContentInfo
+import us.nineworlds.serenity.core.repository.VideoRepository
+import us.nineworlds.serenity.test.InjectingTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EpisodePagingSourceTest : InjectingTest() {
+
+    private val mockRepository = mockk<VideoRepository>(relaxed = true)
+    private val mockVideo = mockk<VideoContentInfo>(relaxed = true)
+
+    private lateinit var pagingSource: EpisodePagingSource
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        pagingSource = EpisodePagingSource(mockRepository, "item1")
+    }
+
+    override fun installTestModules() {
+        scope.installModules(TestModule())
+    }
+
+    inner class TestModule : Module() {
+        init {
+            bind(VideoRepository::class.java).toInstance(mockRepository)
+        }
+    }
+
+    @Test
+    fun `load returns success when repository returns data`() = runTest {
+        val episodes = listOf(mockVideo)
+        coEvery { mockRepository.fetchEpisodes("item1", 0, 30) } returns episodes
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = 0,
+                loadSize = 30,
+                placeholdersEnabled = false
+            )
+        )
+
+        assertThat(result).isInstanceOf(PagingSource.LoadResult.Page::class)
+        val page = result as PagingSource.LoadResult.Page
+        assertThat(page.data).isEqualTo(episodes)
+        assertThat(page.prevKey).isNull()
+        assertThat(page.nextKey).isNull()
+    }
+
+    @Test
+    fun `load returns nextKey when more episodes are available`() = runTest {
+        val episodes = List(30) { mockVideo }
+        coEvery { mockRepository.fetchEpisodes("item1", 0, 30) } returns episodes
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = 0,
+                loadSize = 30,
+                placeholdersEnabled = false
+            )
+        )
+
+        assertThat(result).isInstanceOf(PagingSource.LoadResult.Page::class)
+        val page = result as PagingSource.LoadResult.Page
+        assertThat(page.nextKey).isEqualTo(30)
+    }
+
+    @Test
+    fun `load returns error when repository throws exception`() = runTest {
+        val exception = RuntimeException("Failed to fetch episodes")
+        coEvery { mockRepository.fetchEpisodes(any(), any(), any()) } throws exception
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = 0,
+                loadSize = 30,
+                placeholdersEnabled = false
+            )
+        )
+
+        assertThat(result).isInstanceOf(PagingSource.LoadResult.Error::class)
+        val error = result as PagingSource.LoadResult.Error
+        assertThat(error.throwable).isEqualTo(exception)
+    }
+
+    @Test
+    fun `getRefreshKey returns correct key`() {
+        val state = PagingState<Int, VideoContentInfo>(
+            pages = emptyList(),
+            anchorPosition = 10,
+            config = androidx.paging.PagingConfig(pageSize = 15),
+            leadingPlaceholderCount = 0
+        )
+
+        val refreshKey = pagingSource.getRefreshKey(state)
+        assertThat(refreshKey).isNull()
+    }
+}

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSourceTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSourceTest.kt
@@ -62,7 +62,7 @@ class SimilarItemsPagingSourceTest : InjectingTest() {
         )
 
         assertThat(result).isInstanceOf(PagingSource.LoadResult.Page::class)
-        val page = result as PagingSource.LoadResult.Page
+        val page = result as PagingSource.LoadResult.Page<Int, VideoContentInfo>
         assertThat(page.data).isEqualTo(similarItems)
         assertThat(page.prevKey).isNull()
         assertThat(page.nextKey).isNull()
@@ -82,7 +82,7 @@ class SimilarItemsPagingSourceTest : InjectingTest() {
         )
 
         assertThat(result).isInstanceOf(PagingSource.LoadResult.Page::class)
-        val page = result as PagingSource.LoadResult.Page
+        val page = result as PagingSource.LoadResult.Page<Int, VideoContentInfo>
         assertThat(page.nextKey).isEqualTo(30)
     }
 
@@ -100,15 +100,82 @@ class SimilarItemsPagingSourceTest : InjectingTest() {
         )
 
         assertThat(result).isInstanceOf(PagingSource.LoadResult.Error::class)
-        val error = result as PagingSource.LoadResult.Error
+        val error = result as PagingSource.LoadResult.Error<Int, VideoContentInfo>
         assertThat(error.throwable).isEqualTo(exception)
     }
 
     @Test
-    fun `getRefreshKey returns correct key`() {
+    fun `getRefreshKey returns null when anchorPosition is null`() {
         val state = PagingState<Int, VideoContentInfo>(
             pages = emptyList(),
-            anchorPosition = 10,
+            anchorPosition = null,
+            config = androidx.paging.PagingConfig(pageSize = 15),
+            leadingPlaceholderCount = 0
+        )
+
+        val refreshKey = pagingSource.getRefreshKey(state)
+        assertThat(refreshKey).isNull()
+    }
+
+    @Test
+    fun `getRefreshKey returns null when anchorPosition is not null but closestPageToPosition is null`() {
+        val state = PagingState<Int, VideoContentInfo>(
+            pages = emptyList(),
+            anchorPosition = 0,
+            config = androidx.paging.PagingConfig(pageSize = 15),
+            leadingPlaceholderCount = 0
+        )
+
+        val refreshKey = pagingSource.getRefreshKey(state)
+        assertThat(refreshKey).isNull()
+    }
+
+    @Test
+    fun `getRefreshKey returns prevKey plus pageSize when prevKey is present`() {
+        val page = PagingSource.LoadResult.Page<Int, VideoContentInfo>(
+            data = listOf(mockVideo),
+            prevKey = 0,
+            nextKey = 30
+        )
+        val state = PagingState<Int, VideoContentInfo>(
+            pages = listOf(page),
+            anchorPosition = 0,
+            config = androidx.paging.PagingConfig(pageSize = 15),
+            leadingPlaceholderCount = 0
+        )
+
+        val refreshKey = pagingSource.getRefreshKey(state)
+        assertThat(refreshKey).isEqualTo(15)
+    }
+
+    @Test
+    fun `getRefreshKey returns nextKey minus pageSize when prevKey is null but nextKey is present`() {
+        val page = PagingSource.LoadResult.Page<Int, VideoContentInfo>(
+            data = listOf(mockVideo),
+            prevKey = null,
+            nextKey = 30
+        )
+        val state = PagingState<Int, VideoContentInfo>(
+            pages = listOf(page),
+            anchorPosition = 0,
+            config = androidx.paging.PagingConfig(pageSize = 15),
+            leadingPlaceholderCount = 0
+        )
+
+        val refreshKey = pagingSource.getRefreshKey(state)
+        assertThat(refreshKey).isEqualTo(15)
+    }
+
+    @Test
+    fun `getRefreshKey returns null when both prevKey and nextKey are null`() {
+        val page = PagingSource.LoadResult.Page<Int, VideoContentInfo>(
+            data = listOf(mockVideo),
+            prevKey = null,
+            nextKey = null
+        )
+        val state = PagingState<Int, VideoContentInfo>(
+            pages = listOf(page),
+            anchorPosition = 0,
             config = androidx.paging.PagingConfig(pageSize = 15),
             leadingPlaceholderCount = 0
         )

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSourceTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/core/paging/SimilarItemsPagingSourceTest.kt
@@ -1,0 +1,119 @@
+package us.nineworlds.serenity.core.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNull
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import toothpick.config.Module
+import us.nineworlds.serenity.common.rest.Types
+import us.nineworlds.serenity.core.model.VideoContentInfo
+import us.nineworlds.serenity.core.repository.VideoRepository
+import us.nineworlds.serenity.test.InjectingTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SimilarItemsPagingSourceTest : InjectingTest() {
+
+    private val mockRepository = mockk<VideoRepository>(relaxed = true)
+    private val mockVideo = mockk<VideoContentInfo>(relaxed = true)
+
+    private lateinit var pagingSource: SimilarItemsPagingSource
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        pagingSource = SimilarItemsPagingSource(mockRepository, "item1", Types.MOVIES)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+        closeScope()
+    }
+
+    override fun installTestModules() {
+        scope.installModules(object : Module() {
+            init {
+                bind(VideoRepository::class.java).toInstance(mockRepository)
+            }
+        })
+    }
+
+    @Test
+    fun `load returns success when repository returns data`() = runTest {
+        val similarItems = listOf(mockVideo)
+        coEvery { mockRepository.fetchSimilarItemsList("item1", Types.MOVIES, 0, 30) } returns similarItems
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = 0,
+                loadSize = 30,
+                placeholdersEnabled = false
+            )
+        )
+
+        assertThat(result).isInstanceOf(PagingSource.LoadResult.Page::class)
+        val page = result as PagingSource.LoadResult.Page
+        assertThat(page.data).isEqualTo(similarItems)
+        assertThat(page.prevKey).isNull()
+        assertThat(page.nextKey).isNull()
+    }
+
+    @Test
+    fun `load returns nextKey when more similar items are available`() = runTest {
+        val similarItems = List(30) { mockVideo }
+        coEvery { mockRepository.fetchSimilarItemsList("item1", Types.MOVIES, 0, 30) } returns similarItems
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = 0,
+                loadSize = 30,
+                placeholdersEnabled = false
+            )
+        )
+
+        assertThat(result).isInstanceOf(PagingSource.LoadResult.Page::class)
+        val page = result as PagingSource.LoadResult.Page
+        assertThat(page.nextKey).isEqualTo(30)
+    }
+
+    @Test
+    fun `load returns error when repository throws exception`() = runTest {
+        val exception = RuntimeException("Failed to fetch similar items")
+        coEvery { mockRepository.fetchSimilarItemsList(any(), any(), any(), any()) } throws exception
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = 0,
+                loadSize = 30,
+                placeholdersEnabled = false
+            )
+        )
+
+        assertThat(result).isInstanceOf(PagingSource.LoadResult.Error::class)
+        val error = result as PagingSource.LoadResult.Error
+        assertThat(error.throwable).isEqualTo(exception)
+    }
+
+    @Test
+    fun `getRefreshKey returns correct key`() {
+        val state = PagingState<Int, VideoContentInfo>(
+            pages = emptyList(),
+            anchorPosition = 10,
+            config = androidx.paging.PagingConfig(pageSize = 15),
+            leadingPlaceholderCount = 0
+        )
+
+        val refreshKey = pagingSource.getRefreshKey(state)
+        assertThat(refreshKey).isNull()
+    }
+}

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/core/paging/VideoCategoryPagingSourceTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/core/paging/VideoCategoryPagingSourceTest.kt
@@ -1,0 +1,123 @@
+package us.nineworlds.serenity.core.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNull
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import toothpick.Toothpick
+import toothpick.config.Module
+import us.nineworlds.serenity.common.repository.Result
+import us.nineworlds.serenity.core.model.VideoContentInfo
+import us.nineworlds.serenity.core.repository.CategoryRepository
+import us.nineworlds.serenity.test.InjectingTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class VideoCategoryPagingSourceTest : InjectingTest() {
+
+    private val mockRepository = mockk<CategoryRepository>(relaxed = true)
+    private val mockVideo = mockk<VideoContentInfo>(relaxed = true)
+
+    private lateinit var pagingSource: VideoCategoryPagingSource
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        pagingSource = VideoCategoryPagingSource(mockRepository, "cat1", "item1", "movies")
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+        Toothpick.reset()
+    }
+
+    override fun installTestModules() {
+        scope.installModules(TestModule())
+    }
+
+    inner class TestModule : Module() {
+        init {
+            bind(CategoryRepository::class.java).toInstance(mockRepository)
+        }
+    }
+
+    @Test
+    fun `load returns success when repository returns success`() = runTest {
+        val videos = listOf(mockVideo)
+        coEvery { mockRepository.fetchItemsByCategory("cat1", "item1", "movies", 0, 30) } returns Result.Success(videos)
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = 0,
+                loadSize = 30,
+                placeholdersEnabled = false
+            )
+        )
+
+        assertThat(result).isInstanceOf(PagingSource.LoadResult.Page::class)
+        val page = result as PagingSource.LoadResult.Page
+        assertThat(page.data).isEqualTo(videos)
+        assertThat(page.prevKey).isNull()
+        // Since loadSize is 30 and we only returned 1, nextKey should be null
+        assertThat(page.nextKey).isNull()
+    }
+
+    @Test
+    fun `load returns nextKey when more data is available`() = runTest {
+        val videos = List(30) { mockVideo }
+        coEvery { mockRepository.fetchItemsByCategory("cat1", "item1", "movies", 0, 30) } returns Result.Success(videos)
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = 0,
+                loadSize = 30,
+                placeholdersEnabled = false
+            )
+        )
+
+        assertThat(result).isInstanceOf(PagingSource.LoadResult.Page::class)
+        val page = result as PagingSource.LoadResult.Page
+        assertThat(page.nextKey).isEqualTo(30)
+    }
+
+    @Test
+    fun `load returns error when repository returns error`() = runTest {
+        val exception = Exception("Failed")
+        coEvery { mockRepository.fetchItemsByCategory(any(), any(), any(), any(), any()) } returns Result.Error(exception)
+
+        val result = pagingSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = 0,
+                loadSize = 30,
+                placeholdersEnabled = false
+            )
+        )
+
+        assertThat(result).isInstanceOf(PagingSource.LoadResult.Error::class)
+        val error = result as PagingSource.LoadResult.Error
+        assertThat(error.throwable).isEqualTo(exception)
+    }
+
+    @Test
+    fun `getRefreshKey returns correct key`() {
+        val state = PagingState<Int, VideoContentInfo>(
+            pages = emptyList(),
+            anchorPosition = 10,
+            config = androidx.paging.PagingConfig(pageSize = 15),
+            leadingPlaceholderCount = 0
+        )
+
+        val refreshKey = pagingSource.getRefreshKey(state)
+        assertThat(refreshKey).isNull()
+    }
+}

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/core/repository/CategoryRepositoryTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/core/repository/CategoryRepositoryTest.kt
@@ -1,0 +1,89 @@
+package us.nineworlds.serenity.core.repository
+
+import android.content.res.Resources
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import toothpick.config.Module
+import us.nineworlds.serenity.common.media.model.IMediaContainer
+import us.nineworlds.serenity.common.repository.Result
+import us.nineworlds.serenity.common.rest.SerenityClient
+import us.nineworlds.serenity.common.rest.Types
+import us.nineworlds.serenity.test.InjectingTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CategoryRepositoryTest : InjectingTest() {
+
+    private val mockClient = mockk<SerenityClient>(relaxed = true)
+    private val mockMediaContainer = mockk<IMediaContainer>(relaxed = true)
+
+    private lateinit var repository: CategoryRepository
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        repository = CategoryRepository(mockClient)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+        Dispatchers.resetMain()
+    }
+
+    override fun installTestModules() {
+        scope.installModules(TestModule())
+    }
+
+    inner class TestModule : Module() {
+        init {
+            bind(SerenityClient::class.java).toInstance(mockClient)
+            bind(Resources::class.java).toInstance(mockk(relaxed = true))
+        }
+    }
+
+    @Test
+    fun `fetchItemsByCategory calls client with paging parameters`() = runTest {
+        val categoryId = "cat1"
+        val itemId = "item1"
+        val type = "movies"
+        val startIndex = 0
+        val limit = 30
+
+        coEvery { mockClient.retrieveItemByIdCategory(itemId, categoryId, Types.MOVIES, startIndex, limit) } returns mockMediaContainer
+
+        val result = repository.fetchItemsByCategory(categoryId, itemId, type, startIndex, limit)
+
+        assertThat(result).isInstanceOf(Result.Success::class)
+        coVerify { mockClient.retrieveItemByIdCategory(itemId, categoryId, Types.MOVIES, startIndex, limit) }
+    }
+
+    @Test
+    fun `fetchItemsByCategory maps tvshows correctly`() = runTest {
+        val categoryId = "cat1"
+        val itemId = "item1"
+        val type = "tvshows"
+        val startIndex = 30
+        val limit = 15
+
+        coEvery { mockClient.retrieveItemByIdCategory(itemId, categoryId, Types.SERIES, startIndex, limit) } returns mockMediaContainer
+
+        val result = repository.fetchItemsByCategory(categoryId, itemId, type, startIndex, limit)
+
+        assertThat(result).isInstanceOf(Result.Success::class)
+        coVerify { mockClient.retrieveItemByIdCategory(itemId, categoryId, Types.SERIES, startIndex, limit) }
+    }
+}

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/core/repository/VideoRepositoryTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/core/repository/VideoRepositoryTest.kt
@@ -1,0 +1,101 @@
+package us.nineworlds.serenity.core.repository
+
+import android.content.res.Resources
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import toothpick.config.Module
+import us.nineworlds.serenity.common.media.model.IMediaContainer
+import us.nineworlds.serenity.common.rest.SerenityClient
+import us.nineworlds.serenity.common.rest.Types
+import us.nineworlds.serenity.test.InjectingTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class VideoRepositoryTest : InjectingTest() {
+
+    private val mockClient = mockk<SerenityClient>(relaxed = true)
+    private val mockMediaContainer = mockk<IMediaContainer>(relaxed = true)
+
+    private lateinit var repository: VideoRepository
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        repository = VideoRepository(mockClient)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+        Dispatchers.resetMain()
+        closeScope()
+    }
+
+    override fun installTestModules() {
+        scope.installModules(TestModule())
+    }
+
+    inner class TestModule : Module() {
+        init {
+            bind(SerenityClient::class.java).toInstance(mockClient)
+            bind(Resources::class.java).toInstance(mockk(relaxed = true))
+        }
+    }
+
+    @Test
+    fun `fetchEpisodes calls client with paging parameters`() = runTest {
+        val itemId = "item1"
+        val startIndex = 0
+        val limit = 30
+
+        coEvery { mockClient.retrieveEpisodes(itemId, startIndex, limit) } returns mockMediaContainer
+
+        val result = repository.fetchEpisodes(itemId, startIndex, limit)
+
+        assertThat(result).isInstanceOf(List::class)
+        coVerify { mockClient.retrieveEpisodes(itemId, startIndex, limit) }
+    }
+
+    @Test
+    fun `fetchSimilarItems calls client with paging parameters`() = runTest {
+        val itemId = "item1"
+        val type = Types.MOVIES
+        val startIndex = 0
+        val limit = 30
+
+        coEvery { mockClient.fetchSimilarItemById(itemId, type, startIndex, limit) } returns mockMediaContainer
+
+        val result = repository.fetchSimilarItems(itemId, type, startIndex, limit)
+
+        assertThat(result).isInstanceOf(IMediaContainer::class)
+        coVerify { mockClient.fetchSimilarItemById(itemId, type, startIndex, limit) }
+    }
+
+    @Test
+    fun `fetchSimilarItemsList calls client with paging parameters`() = runTest {
+        val itemId = "item1"
+        val type = Types.MOVIES
+        val startIndex = 0
+        val limit = 30
+
+        coEvery { mockClient.fetchSimilarItemById(itemId, type, startIndex, limit) } returns mockMediaContainer
+
+        val result = repository.fetchSimilarItemsList(itemId, type, startIndex, limit)
+
+        assertThat(result).isInstanceOf(List::class)
+        coVerify { mockClient.fetchSimilarItemById(itemId, type, startIndex, limit) }
+    }
+}

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsMVPPresenterTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/activity/leanback/details/DetailsMVPPresenterTest.kt
@@ -1,0 +1,179 @@
+package us.nineworlds.serenity.ui.activity.leanback.details
+
+import android.content.res.Resources
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import toothpick.Toothpick
+import toothpick.config.Module
+import us.nineworlds.serenity.common.media.model.IDirectory
+import us.nineworlds.serenity.common.media.model.IMediaContainer
+import us.nineworlds.serenity.common.media.model.IVideo
+import us.nineworlds.serenity.common.rest.SerenityClient
+import us.nineworlds.serenity.common.rest.Types
+import us.nineworlds.serenity.core.repository.VideoRepository
+import us.nineworlds.serenity.core.util.AndroidHelper
+import us.nineworlds.serenity.test.InjectingTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class DetailsMVPPresenterTest : InjectingTest() {
+
+    private val mockRepository: VideoRepository = mockk(relaxed = true)
+    private val mockView: DetailsView = mockk(relaxed = true)
+    private val mockSerenityClient: SerenityClient = mockk(relaxed = true)
+    private val mockResources: Resources = mockk(relaxed = true)
+    private val mockAndroidHelper: AndroidHelper = mockk(relaxed = true)
+
+    private lateinit var presenter: DetailsMVPPresenter
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        every { mockSerenityClient.baseURL() } returns "http://localhost:8096/"
+        presenter = DetailsMVPPresenter()
+        presenter.attachView(mockView)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        clearAllMocks()
+        Toothpick.reset()
+    }
+
+    @Test
+    fun `loadItem for tvshows updates details, seasons and episodes`() = runTest(UnconfinedTestDispatcher()) {
+        val itemId = "123"
+        val type = "tvshows"
+        val mockMediaContainer = mockk<IMediaContainer>(relaxed = true)
+        val mockDirectory = mockk<IDirectory>(relaxed = true)
+
+        every { mockDirectory.key } returns "season1"
+        every { mockDirectory.rating } returns "0.0"
+        every { mockDirectory.leafCount } returns "0"
+        every { mockDirectory.viewedLeafCount } returns "0"
+        every { mockMediaContainer.directories } returns listOf(mockDirectory)
+        every { mockMediaContainer.size } returns 1
+        coEvery { mockRepository.fetchItemById(itemId) } returns mockMediaContainer
+        coEvery { mockRepository.fetchSeasons(itemId) } returns mockMediaContainer
+        coEvery { mockRepository.fetchEpisodes(any(), any(), any()) } returns emptyList()
+
+        presenter.loadItem(itemId, type)
+
+        advanceUntilIdle()
+
+        verify { mockView.updateDetails(any()) }
+        verify { mockView.addSeasons(any()) }
+        verify { mockView.updateSeasonEpisodes(any(), any()) }
+    }
+
+    @Test
+    fun `loadItem for movies updates details and loads similar items`() = runTest(UnconfinedTestDispatcher()) {
+        val itemId = "123"
+        val type = "movies"
+        val mockMediaContainer = mockk<IMediaContainer>(relaxed = true)
+        val mockVideo = mockk<IVideo>(relaxed = true)
+
+        every { mockVideo.type } returns "movie"
+        every { mockVideo.viewOffset } returns 0
+        every { mockVideo.duration } returns 0
+        every { mockMediaContainer.videos } returns listOf(mockVideo)
+        every { mockMediaContainer.size } returns 1
+        coEvery { mockRepository.fetchItemById(itemId) } returns mockMediaContainer
+        coEvery { mockRepository.fetchSimilarItemsList(any(), any(), any(), any()) } returns emptyList()
+
+        presenter.loadItem(itemId, type)
+
+        advanceUntilIdle()
+
+        verify { mockView.updateDetails(any()) }
+        verify { mockView.addSimilarItems(any()) }
+    }
+
+    @Test
+    fun `loadSimilarItems for tvshows calls addSimilarSeries`() = runTest(UnconfinedTestDispatcher()) {
+        val itemId = "123"
+        val type = "tvshows"
+        val mockMediaContainer = mockk<IMediaContainer>(relaxed = true)
+        val mockDirectory = mockk<IDirectory>(relaxed = true)
+
+        every { mockDirectory.rating } returns "0.0"
+        every { mockDirectory.leafCount } returns "0"
+        every { mockDirectory.viewedLeafCount } returns "0"
+        every { mockMediaContainer.directories } returns listOf(mockDirectory)
+        every { mockMediaContainer.size } returns 1
+        coEvery { mockRepository.fetchSimilarItems(itemId, Types.SERIES) } returns mockMediaContainer
+
+        presenter.loadSimilarItems(itemId, type)
+
+        advanceUntilIdle()
+
+        verify { mockView.addSimilarSeries(any()) }
+    }
+
+    @Test
+    fun `loadSimilarItems for movies calls addSimilarItems`() = runTest(UnconfinedTestDispatcher()) {
+        val itemId = "123"
+        val type = "movies"
+
+        coEvery { mockRepository.fetchSimilarItemsList(any(), any(), any(), any()) } returns emptyList()
+
+        presenter.loadSimilarItems(itemId, type)
+
+        advanceUntilIdle()
+
+        verify { mockView.addSimilarItems(any()) }
+    }
+
+    @Test
+    fun `loadItem for unknown type defaults to movie behavior`() = runTest(UnconfinedTestDispatcher()) {
+        val itemId = "123"
+        val type = "unknown"
+        val mockMediaContainer = mockk<IMediaContainer>(relaxed = true)
+        val mockVideo = mockk<IVideo>(relaxed = true)
+
+        every { mockVideo.type } returns "movie"
+        every { mockVideo.viewOffset } returns 0
+        every { mockVideo.duration } returns 0
+        every { mockMediaContainer.videos } returns listOf(mockVideo)
+        every { mockMediaContainer.size } returns 1
+        coEvery { mockRepository.fetchItemById(itemId) } returns mockMediaContainer
+        coEvery { mockRepository.fetchSimilarItemsList(any(), any(), any(), any()) } returns emptyList()
+
+        presenter.loadItem(itemId, type)
+
+        advanceUntilIdle()
+
+        verify { mockView.updateDetails(any()) }
+        verify { mockView.addSimilarItems(any()) }
+    }
+
+    override fun installTestModules() {
+        scope.installTestModules(TestModule())
+    }
+
+    inner class TestModule : Module() {
+        init {
+            bind(VideoRepository::class.java).toInstance(mockRepository)
+            bind(SerenityClient::class.java).toInstance(mockSerenityClient)
+            bind(Resources::class.java).toInstance(mockResources)
+            bind(AndroidHelper::class.java).toInstance(mockAndroidHelper)
+        }
+    }
+}

--- a/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/leanback/adapters/SerenityPagingDataAdapterTest.kt
+++ b/serenity-app/src/test/kotlin/us/nineworlds/serenity/ui/leanback/adapters/SerenityPagingDataAdapterTest.kt
@@ -1,0 +1,112 @@
+package us.nineworlds.serenity.ui.leanback.adapters
+
+import android.os.Looper
+import androidx.leanback.widget.ObjectAdapter
+import androidx.leanback.widget.Presenter
+import androidx.paging.PagingData
+import androidx.recyclerview.widget.DiffUtil
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import io.mockk.clearAllMocks
+import io.mockk.mockk
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config
+class SerenityPagingDataAdapterTest {
+
+    private val mockPresenter: Presenter = mockk(relaxed = true)
+    private val diffCallback = object : DiffUtil.ItemCallback<String>() {
+        override fun areItemsTheSame(oldItem: String, newItem: String): Boolean = oldItem == newItem
+        override fun areContentsTheSame(oldItem: String, newItem: String): Boolean = oldItem == newItem
+    }
+
+    private lateinit var adapter: SerenityPagingDataAdapter<String>
+
+    @Before
+    fun setUp() {
+        adapter = SerenityPagingDataAdapter(mockPresenter, diffCallback)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun size_returnsInternalAdapterSize() {
+        assertThat(adapter.size()).isEqualTo(0)
+    }
+
+    @Test
+    fun get_returnsNull_whenPositionIsOutOfBounds() {
+        assertThat(adapter.get(0)).isNull()
+    }
+
+    @Test
+    fun constructor_withPresenter_createsPresenterSelector() {
+        val presenter = adapter.presenterSelector.getPresenter("test")
+        assertThat(presenter).isEqualTo(mockPresenter)
+    }
+
+    @Test
+    fun submitData_updatesSizeAndItems() = runTest(UnconfinedTestDispatcher()) {
+        val pagingData = PagingData.from(listOf("item1", "item2"))
+
+        backgroundScope.launch {
+            adapter.submitData(pagingData)
+        }
+
+        advanceUntilIdle()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertThat(adapter.size()).isEqualTo(2)
+        assertThat(adapter.get(0)).isEqualTo("item1")
+        assertThat(adapter.get(1)).isEqualTo("item2")
+    }
+
+    @Test
+    fun dataObserver_triggersNotifyChanged() = runTest(UnconfinedTestDispatcher()) {
+        var notified = false
+        val observer = object : ObjectAdapter.DataObserver() {
+            override fun onChanged() {
+                notified = true
+            }
+
+            override fun onItemRangeChanged(positionStart: Int, itemCount: Int) {
+                notified = true
+            }
+
+            override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+                notified = true
+            }
+
+            override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+                notified = true
+            }
+        }
+        adapter.registerObserver(observer)
+
+        val pagingData = PagingData.from(listOf("item1"))
+        backgroundScope.launch {
+            adapter.submitData(pagingData)
+        }
+
+        advanceUntilIdle()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertThat(notified).isTrue()
+    }
+}

--- a/serenity-common/src/main/java/us/nineworlds/serenity/common/rest/SerenityClient.kt
+++ b/serenity-common/src/main/java/us/nineworlds/serenity/common/rest/SerenityClient.kt
@@ -9,6 +9,9 @@ interface SerenityClient {
     fun fetchSimilarItemById(itemId: String, types: Types): IMediaContainer
 
     @Throws(Exception::class)
+    fun fetchSimilarItemById(itemId: String, types: Types, startIndex: Int = 0, limit: Int? = null): IMediaContainer
+
+    @Throws(Exception::class)
     fun fetchItemById(itemId: String): IMediaContainer
 
     @Throws(Exception::class)
@@ -40,6 +43,9 @@ interface SerenityClient {
 
     @Throws(Exception::class)
     fun retrieveEpisodes(key: String): IMediaContainer
+
+    @Throws(Exception::class)
+    fun retrieveEpisodes(key: String, startIndex: Int = 0, limit: Int? = null): IMediaContainer
 
     @Throws(Exception::class)
     fun retrieveMovieMetaData(key: String): IMediaContainer


### PR DESCRIPTION
Updates the code to make use of the PagingAdapters and Paging Libraries.  This is a pretty big refactor adding, paging support to the Serenity Client, as well as updating both the EmbyAPIClient and JellfyinClients for this support.

Unit tests have been added for most of the code changes.  

With these changes, time to first image appearing is reduced by almost half on a TCL TV.

Implements #374 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide pagination for similar items, episodes, categories and detail screens; paging-aware adapters for Leanback UI.

* **Performance**
  * Parallelized media list construction for faster content availability.

* **Chores**
  * Added runtime paging libraries and propagated pagination support through clients, services, repositories, presenters, and UI.

* **Tests**
  * New unit tests for paging sources, adapters, repositories, and related presenter behavior.

* **Documentation**
  * Added a multi-phase paging support plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->