### PR TITLE
fix: Remove Joda Time dependency

### DIFF
--- a/emby-lib/build.gradle.kts
+++ b/emby-lib/build.gradle.kts
@@ -31,6 +31,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true
     }
 
     sourceSets {
@@ -54,6 +55,7 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
     lintChecks(project(":lint-rules"))
 
     api(project(":serenity-common"))
@@ -80,11 +82,11 @@ dependencies {
     implementation(libs.eventbus)
     implementation(libs.moshi)
     implementation(libs.retrofit.moshi)
-    implementation(libs.joda.time)
     implementation(libs.retrofit)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging.interceptor)
     implementation(libs.timber)
+    implementation(libs.androidx.annotation)
 
     testImplementation(libs.junit)
     testImplementation(libs.assertj.core)

--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/moshi/LocalDateJsonAdapter.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/moshi/LocalDateJsonAdapter.kt
@@ -1,22 +1,20 @@
 package us.nineworlds.serenity.emby.moshi
 
+import android.annotation.SuppressLint
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
-import org.joda.time.LocalDateTime
-import org.joda.time.format.DateTimeFormat
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
+@SuppressLint("NewApi")
 class LocalDateJsonAdapter : JsonAdapter<LocalDateTime>() {
-    override fun fromJson(reader: JsonReader): LocalDateTime? {
-        val dateTime = reader.nextString()!!.replaceAfter(".", "")
-        val dateformater = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH':'mm':'ss'.'")
-//      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSS'Z'")
-//    } else if(dateTime!!.contains("+")) {
-//    } else {
-//      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ")
-//    }
 
-        return LocalDateTime.parse(dateTime, dateformater)
+    private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.")
+
+    override fun fromJson(reader: JsonReader): LocalDateTime? {
+        val dateTimeString = reader.nextString()?.replaceAfter(".", "") ?: return null
+        return LocalDateTime.parse(dateTimeString, dateFormatter)
     }
 
     override fun toJson(writer: JsonWriter, value: LocalDateTime?) {

--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClient.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClient.kt
@@ -7,12 +7,12 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.File
 import java.io.IOException
+import java.time.LocalDateTime
 import java.util.UUID
 import me.jessyan.retrofiturlmanager.RetrofitUrlManager
 import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
-import org.joda.time.LocalDateTime
 import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory

--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/model/ItemsModel.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/model/ItemsModel.kt
@@ -1,7 +1,7 @@
 package us.nineworlds.serenity.emby.server.model
 
 import com.squareup.moshi.Json
-import org.joda.time.LocalDateTime
+import java.time.LocalDateTime
 
 data class QueryResult(@Json(name = "Items") val items: List<Item>, @Json(name = "TotalRecordCount") val totalRecordCount: Int)
 

--- a/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/model/UsersModel.kt
+++ b/emby-lib/src/main/kotlin/us/nineworlds/serenity/emby/server/model/UsersModel.kt
@@ -1,7 +1,7 @@
 package us.nineworlds.serenity.emby.server.model
 
 import com.squareup.moshi.Json
-import org.joda.time.LocalDateTime
+import java.time.LocalDateTime
 
 data class PublicUserInfo(
     @Json(name = "Name") val name: String?,

--- a/emby-lib/src/test/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClientTest.kt
+++ b/emby-lib/src/test/kotlin/us/nineworlds/serenity/emby/server/api/EmbyAPIClientTest.kt
@@ -7,7 +7,6 @@ import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
-import net.danlew.android.joda.JodaTimeAndroid
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -27,7 +26,6 @@ class EmbyAPIClientTest {
     @Before
     fun setUp() {
         ShadowLog.stream = System.out
-        JodaTimeAndroid.init(ApplicationProvider.getApplicationContext())
 
         client = EmbyAPIClient(context = ApplicationProvider.getApplicationContext())
         // Update this for local testing of the client and make sure it works

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,6 @@ androidPriorityJobQueueVersion = "2.0.1"
 eventBus = "3.3.1"
 moshiKotlinVersion = "1.15.2"
 retrofitVersion = "2.9.0"
-jodaTimeVersion = "2.10.9.1"
 timberVersion = "5.0.1"
 media3Version = "1.9.0"
 simpleXmlVersion = "2.7.1"
@@ -65,6 +64,7 @@ coreKtxVersion = "1.17.0"
 espressoCoreVersion = "3.5.1"
 lifecycleProcessVersion = "2.10.0"
 datastore = "1.1.2"
+desugarVersion = "2.1.4"
 
 [libraries]
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotationVersion" }
@@ -112,7 +112,6 @@ okhttp-urlconnection = { module = "com.squareup.okhttp3:okhttp-urlconnection", v
 recyclerview-animators = { module = "jp.wasabeef:recyclerview-animators", version.ref = "recyclerviewAnimatorsVersion" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofitVersion" }
 retrofit-moshi = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofitVersion" }
-joda-time = { group = "net.danlew", name = "android.joda", version.ref = "jodaTimeVersion" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttpVersion" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttpVersion" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timberVersion" }
@@ -120,6 +119,7 @@ resourceful = { group = "com.github.rstanic12", name = "Resourceful", version.re
 simple-xml = { group = "org.simpleframework", name = "simple-xml", version.ref = "simpleXmlVersion" }
 
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
+desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarVersion" }
 
 # Toothpick
 toothpick-runtime = { group = "com.github.stephanenicolas.toothpick", name = "toothpick-runtime", version.ref = "toothPickVersion"}

--- a/jellyfin-lib/build.gradle.kts
+++ b/jellyfin-lib/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("com.android.library")
     kotlin("android")
@@ -28,6 +31,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true
     }
 
     sourceSets {
@@ -51,6 +55,7 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
     lintChecks(project(":lint-rules"))
 
     api(project(":serenity-common"))
@@ -77,7 +82,6 @@ dependencies {
     implementation(libs.eventbus)
     implementation(libs.moshi)
     implementation(libs.retrofit.moshi)
-    implementation(libs.joda.time)
     implementation(libs.retrofit)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging.interceptor)

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/moshi/LocalDateJsonAdapter.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/moshi/LocalDateJsonAdapter.kt
@@ -3,20 +3,15 @@ package us.nineworlds.serenity.jellyfin.moshi
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
-import org.joda.time.LocalDateTime
-import org.joda.time.format.DateTimeFormat
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 class LocalDateJsonAdapter : JsonAdapter<LocalDateTime>() {
-    override fun fromJson(reader: JsonReader): LocalDateTime? {
-        val dateTime = reader.nextString()!!.replaceAfter(".", "")
-        val dateformater = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH':'mm':'ss'.'")
-//      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSS'Z'")
-//    } else if(dateTime!!.contains("+")) {
-//    } else {
-//      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ")
-//    }
+    private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.")
 
-        return LocalDateTime.parse(dateTime, dateformater)
+    override fun fromJson(reader: JsonReader): LocalDateTime? {
+        val dateTimeString = reader.nextString()?.replaceAfter(".", "") ?: return null
+        return LocalDateTime.parse(dateTimeString, dateFormatter)
     }
 
     override fun toJson(writer: JsonWriter, value: LocalDateTime?) {

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClient.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/api/JellyfinAPIClient.kt
@@ -7,12 +7,12 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.File
 import java.io.IOException
+import java.time.LocalDateTime
 import java.util.UUID
 import me.jessyan.retrofiturlmanager.RetrofitUrlManager
 import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
-import org.joda.time.LocalDateTime
 import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/model/ItemsModel.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/model/ItemsModel.kt
@@ -1,7 +1,7 @@
 package us.nineworlds.serenity.jellyfin.server.model
 
 import com.squareup.moshi.Json
-import org.joda.time.LocalDateTime
+import java.time.LocalDateTime
 
 data class QueryResult(@Json(name = "Items") val items: List<Item>, @Json(name = "TotalRecordCount") val totalRecordCount: Int)
 

--- a/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/model/UsersModel.kt
+++ b/jellyfin-lib/src/main/kotlin/us/nineworlds/serenity/jellyfin/server/model/UsersModel.kt
@@ -1,7 +1,7 @@
 package us.nineworlds.serenity.jellyfin.server.model
 
 import com.squareup.moshi.Json
-import org.joda.time.LocalDateTime
+import java.time.LocalDateTime
 
 data class PublicUserInfo(
     @Json(name = "Name") val name: String?,

--- a/serenity-app/build.gradle.kts
+++ b/serenity-app/build.gradle.kts
@@ -76,6 +76,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true
     }
 
     buildTypes {
@@ -120,6 +121,7 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
     lintChecks(project(":lint-rules"))
 
     implementation(platform(libs.firebase.bom))
@@ -185,7 +187,6 @@ dependencies {
 
     implementation(libs.moshi)
     implementation(libs.retrofit.moshi)
-    implementation(libs.joda.time)
     implementation(libs.retrofit)
     implementation(libs.flexbox)
     // implementation("com.henryblue.library:tvrecyclerview:1.2.2")

--- a/serenity-app/src/main/java/us/nineworlds/serenity/SerenityApplication.kt
+++ b/serenity-app/src/main/java/us/nineworlds/serenity/SerenityApplication.kt
@@ -40,7 +40,6 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import net.danlew.android.joda.JodaTimeAndroid
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -85,7 +84,6 @@ open class SerenityApplication : Application() {
 
     lateinit var eventBus: EventBus
     private fun init() {
-        JodaTimeAndroid.init(this)
         inject()
         sendStartedApplicationEvent()
         eventBus = EventBus.getDefault()


### PR DESCRIPTION
Migrate to using the built in Java date time library.  Desugar on devices that don't support it natively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Replaced legacy date/time library with Java Time API for improved maintainability and reduced dependencies.
  * Enabled core library desugaring support to enhance Android compatibility across supported versions.
  * Removed Joda-Time runtime initialization calls.

* **Refactor**
  * Updated date/time handling throughout the application to use standard Java Time APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->