### PR TITLE
Spec Driven Development Enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,13 @@ Before providing any code or plan:
 
 ---
 
+## Phased Spec-Driven Development (SDD)
+**PROTOCOL MANDATORY:** For any complex task (> 2 files or architectural changes), you MUST follow the Phased GSD protocol.
+- **Instruction Set:** @./prompts/agents/SPEC_WRITER.md
+- **Task Template:** @./prompts/templates/TASK_SPEC.md
+
+---
+
 ## Core Protocols & Constraints
 @./prompts/agents/CONSTRAINTS.md
 
@@ -36,5 +43,6 @@ Serenity for Android is a media server client for Android (Plex/Emby).
 ## Agent Decision Checklist
 1. **Task Scope**: Is it small/defined?
 2. **Permission**: Received written approval?
-3. **Constraints**: Checked against CONSTRAINTS.md?
-4. **Verification**: Manual steps included?
+3. **Complexity**: Does it require a Phased GSD Spec? (See @SPEC_WRITER.md)
+4. **Constraints**: Checked against CONSTRAINTS.md?
+5. **Verification**: Manual steps included?

--- a/prompts/agents/COMMUNICATION.md
+++ b/prompts/agents/COMMUNICATION.md
@@ -1,5 +1,6 @@
 ## Collaboration & Templates
 - **Permission First**: Request explicit approval before acting.
+- **Complexity Threshold**: Any task affecting more than 2 files, involving architectural changes, or adding new libraries REQUIRES a Phased GSD Spec (see SDD Protocol).
 - **Action Plan**: Present summary, paths, risks, and verification steps.
 - **Issue Template**: "I detected [problem]. Proposed fix: [summary]. Files: [paths]. Risks: [brief]. Do you approve?"
 - **Pair Programming**: You are the coder, the end user will run tests. Ask your pair to run any tests.

--- a/prompts/agents/SPEC_WRITER.md
+++ b/prompts/agents/SPEC_WRITER.md
@@ -1,0 +1,18 @@
+# Persona: Technical Architect (Spec Writer)
+
+You are a Senior Technical Architect responsible for ensuring all complex changes follow a rigorous, spec-driven process. Your primary goal is to eliminate "Vibe Coding" by enforcing a Phased GSD (Goal, Steps, Deliverables) protocol.
+
+## Core Mandate
+When a user request is complex (affects > 2 files), involves architectural changes, or is vague:
+1. **DO NOT write code immediately.**
+2. **INTERVIEW the user** to gather missing context (relevant files, technical constraints, specific goals).
+3. **GENERATE a Phased GSD Spec** using the template at `prompts/templates/TASK_SPEC.md`.
+4. **MANDATE human approval** after each Phase before proceeding to the next one.
+
+## Reporting Constraint
+- **Do NOT generate summary or report Markdown files upon task completion.** Focus only on the requested code changes and verification steps within the conversation or the spec file itself.
+
+## Decision Logic
+- **Simple Tasks (1-2 files, minor logic):** Proceed with standard protocol (Plan -> Permission -> Execute).
+- **Complex Tasks (> 2 files, New Libs, Refactors):** Trigger the Spec-First workflow.
+- **Vague Requests:** Ask clarifying questions until a Phased GSD Spec can be constructed.

--- a/prompts/plans/sdd_implementation_v1.md
+++ b/prompts/plans/sdd_implementation_v1.md
@@ -1,0 +1,157 @@
+# Implementation Plan: Phased Spec-Driven Development (SDD)
+**Status:** PROPOSED  
+**Version:** 1.6.0  
+**Target:** Standardized AI Workflow (Project Agnostic)
+
+## 1. Scope and Summary
+*   **Scope:** This protocol applies to all AI-assisted development within any software project. It governs how architectural changes, refactors, and new features are planned and executed by AI Agents.
+*   **Summary:** To eliminate "Vibe Coding" and ensure consistency, this plan implements a **Spec-First Protocol**. Agents must generate a **Phased GSD (Goal, Steps, Deliverables)** document before writing code. Each phase must include its own verification steps and require explicit human approval before the next phase begins.
+
+## 2. User Guide: How to Generate a Spec
+To generate a new specification using this protocol, follow these steps:
+
+1.  **Reference this Plan:** In your prompt to the AI, reference this file: *"Using the protocol in @sdd_implementation_v1.md, create a Phased GSD Spec for [Task Description]."*
+2.  **Complexity Check:** If the task affects > 2 files, introduces a new library, or changes architecture, the Agent must refuse to code until the spec is finalized.
+3.  **Collaborative Refinement:** The Agent will interview you for context (Files, Constraints, Goals).
+4.  **Template Adherence:** Ensure the Agent uses the `TASK_SPEC.md` structure (Goal, Context, Phases with Verification/Approval Gates).
+
+## 3. User Guide: How to Execute a Generated Spec
+Once a spec (e.g., `refactor_feature_x.md`) is generated and approved, follow this execution workflow:
+
+1.  **Initialize the Phase:** Tell the Agent: *"Follow Phase 1 of @refactor_feature_x.md. Do not proceed to Phase 2 until I verify and approve."*
+2.  **Context Loading:** Ensure the Agent has read the spec file and all relevant source files listed in the "Context" section.
+3.  **Atomic Execution:** The Agent performs the tasks listed in the current Phase.
+4.  **Verification:** The Agent must perform the "Verification" steps listed for that Phase and report results.
+5.  **Human Gate:** You must review the changes and verification results. Use the phrase *"Phase 1 Approved. Proceed to Phase 2"* to move forward.
+
+## 4. Example: Phased GSD Spec (Moshi Conversion)
+*Below is an example of what a generated spec looks like.*
+
+```markdown
+# [SPEC] Convert Directory.java to Moshi/Kotlin
+## Goal
+Migrate legacy Java model to Kotlin with Moshi JSON parsing.
+
+## Context
+- **Files:** `Directory.java`, `SerenityClient.kt`
+- **Constraint:** Must maintain field naming compatibility with existing API.
+
+## Phase 1: Model Conversion
+### Tasks
+- [ ] Convert `Directory.java` to `Directory.kt` (Data Class).
+- [ ] Add `@Json` annotations for Moshi.
+### Verification
+- Unit test: `DirectoryTest` passes with sample JSON.
+### [WAIT FOR APPROVAL]
+
+## Phase 2: Integration
+### Tasks
+- [ ] Update `SerenityClient` to use `MoshiConverterFactory`.
+- [ ] Remove `Gson` references if unused.
+### Verification
+- Please verify the project builds and tests run.
+### [WAIT FOR APPROVAL]
+```
+
+---
+
+## Phase 1: Discovery & Templates
+*Goal: Identify the environment and establish the standardized structure for specifications.*
+
+- [ ] **Task 1.1: Identify Target Agent(s)**
+  - **Action:** Ask the user which AI tool(s) are being targeted (e.g., GitHub Copilot, Android Studio Gemini, Cursor, Claude).
+  - **Outcome:** Document the target agent(s) to tailor the configuration files in Phase 2.
+- [ ] **Task 1.2: Define Reporting Requirements**
+  - **Action:** Ask the user if completion summary reports (Markdown files) should be generated.
+  - **Constraint:** If negative, include the instruction: `Do NOT generate summary or report Markdown file upon completion`. (Note: Targets Claude specifically).
+- [ ] **Task 1.3: Create Standardized Prompt Directory**
+  - Create a designated directory for AI prompts and templates (e.g., `.ai/templates/` or `prompts/templates/`).
+- [ ] **Task 1.4: Create `TASK_SPEC.md` Template**
+  - Define a project-agnostic Phased GSD structure inspired by [GitHub Spec-Kit](https://github.com/github/spec-kit) and [GSD](https://github.com/gsd-build/get-shit-done).
+  - **Template Structure:**
+    ```markdown
+    # [TITLE]
+    ## Goal
+    - [High-level objective]
+    
+    ## Context
+    - **Current State:** [Brief description]
+    - **Constraints:** [Technical/Architectural limits]
+    - **Files:** [Paths to relevant files]
+    
+    ## Phase 1: [Name]
+    ### Tasks
+    - [ ] Task 1: [Details]
+    - [ ] Task 2: [Details]
+    ### Verification
+    - [Test command or manual check]
+    ### [WAIT FOR APPROVAL]
+    
+    ## Phase 2: [Name]
+    ...
+    
+    ## Final Deliverables
+    - [List of files/artifacts]
+    ```
+
+**Phase 1 Verification:**
+1.  Target agent(s) and reporting preferences documented.
+2.  Template directory exists.
+3.  `TASK_SPEC.md` reviewed for clarity and phasing.
+4.  **STOP: Wait for Human Approval.**
+
+---
+
+## Phase 2: Agent Intelligence (The Spec Writer)
+*Goal: Define a persona and generate agent-specific configuration.*
+
+- [ ] **Task 2.1: Create `SPEC_WRITER.md` Instruction Set**
+  - **Persona Example:**
+    ```markdown
+    # Persona: Technical Architect (Spec Writer)
+    When a request is complex or vague:
+    1. DO NOT write code.
+    2. INTERVIEW the user for missing context (Files, Constraints, Goal).
+    3. GENERATE a Phased GSD Spec using the `TASK_SPEC.md` template.
+    4. MANDATE approval after each Phase.
+    
+    [ADD CONDITIONAL CONSTRAINT FROM TASK 1.2 HERE IF NEGATIVE]
+    ```
+  - Add logic to identify "Vibe" requests.
+- [ ] **Task 2.2: Generate Agent-Specific Configuration Files**
+  - Based on Target Agent (Task 1.1):
+    - **GitHub Copilot:** `.github/copilot-instructions.md`
+    - **Cursor:** `.cursorrules`
+    - **Claude/Gemini/Custom:** `AGENTS.md` (Referencing the SDD protocol).
+
+**Phase 2 Verification:**
+1.  `SPEC_WRITER.md` enforces phasing and refusal logic.
+2.  Agent-specific config created and correctly references SDD.
+3.  **STOP: Wait for Human Approval.**
+
+---
+
+## Phase 3: Protocol Integration
+*Goal: Formalize the "Phased Spec-First" rule in core developer documentation.*
+
+- [ ] **Task 3.1: Update Communication Rules**
+  - Update `COMMUNICATION.md` to include the "Complexity Threshold" (e.g., > 2 files or architectural changes require a Phased Spec).
+- [ ] **Task 3.2: Finalize System Prompt Manifest**
+  - Ensure the root AI manifest (e.g., `AGENTS.md`) is updated to include the Spec-First requirement.
+
+**Phase 3 Verification:**
+1.  Review `COMMUNICATION.md` and `AGENTS.md` diffs.
+2.  **STOP: Wait for Human Approval.**
+
+---
+
+## Phase 4: Workflow Validation
+*Goal: Prove the system prevents Vibe Coding in the targeted environment.*
+
+- [ ] **Task 4.1: Simulation Test**
+  - **Trigger:** "Update the Directory model to use Moshi and Kotlin."
+  - **Expected Result:** Agent refuses code, interviews user, and produces a Phased GSD Spec.
+
+**Phase 4 Verification:**
+1.  Success if Agent follows protocol.
+2.  **FINAL APPROVAL: Implementation Complete.**

--- a/prompts/plans/sdd_implementation_v1.md
+++ b/prompts/plans/sdd_implementation_v1.md
@@ -155,3 +155,28 @@ Migrate legacy Java model to Kotlin with Moshi JSON parsing.
 **Phase 4 Verification:**
 1.  Success if Agent follows protocol.
 2.  **FINAL APPROVAL: Implementation Complete.**
+
+---
+
+## License
+MIT License
+
+Copyright (c) 2026 David Carver and NineWorlds
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/prompts/plans/sdd_implementation_v1.md
+++ b/prompts/plans/sdd_implementation_v1.md
@@ -1,28 +1,32 @@
 # Implementation Plan: Phased Spec-Driven Development (SDD)
 **Status:** PROPOSED  
-**Version:** 1.6.0  
-**Target:** Standardized AI Workflow (Project Agnostic)
+**Version:** 1.6.2  
+**Target:** Standardized AI Workflow (Universal LLM/Agent Compatibility)
 
 ## 1. Scope and Summary
-*   **Scope:** This protocol applies to all AI-assisted development within any software project. It governs how architectural changes, refactors, and new features are planned and executed by AI Agents.
-*   **Summary:** To eliminate "Vibe Coding" and ensure consistency, this plan implements a **Spec-First Protocol**. Agents must generate a **Phased GSD (Goal, Steps, Deliverables)** document before writing code. Each phase must include its own verification steps and require explicit human approval before the next phase begins.
+*   **Scope:** This protocol applies to all AI-assisted development (features, refactors, migrations).
+*   **Summary:** To eliminate "Vibe Coding" and ensure consistency, this plan implements a **Spec-First Protocol**. Agents must generate a **Phased GSD (Goal, Steps, Deliverables)** document before writing any production code. Each phase must include its own verification steps and requires explicit human approval before the next phase begins.
+*   **Agnostic Referencing:** All references to files using `@filename` or `./path` notation point to the absolute or relative paths within the project repository.
 
 ## 2. User Guide: How to Generate a Spec
-To generate a new specification using this protocol, follow these steps:
+To trigger a new specification, use the following prompt pattern:
 
-1.  **Reference this Plan:** In your prompt to the AI, reference this file: *"Using the protocol in @sdd_implementation_v1.md, create a Phased GSD Spec for [Task Description]."*
-2.  **Complexity Check:** If the task affects > 2 files, introduces a new library, or changes architecture, the Agent must refuse to code until the spec is finalized.
-3.  **Collaborative Refinement:** The Agent will interview you for context (Files, Constraints, Goals).
-4.  **Template Adherence:** Ensure the Agent uses the `TASK_SPEC.md` structure (Goal, Context, Phases with Verification/Approval Gates).
+> *"Using the protocol in `prompts/plans/sdd_implementation_v1.md`, create a Phased GSD Spec for [Task Description]."*
+
+**Agent Logic (System Instructions):**
+1.  **Complexity Check (MANDATORY REFUSAL):** If the task affects > 2 files, introduces a new library, or changes architecture, you are **PROHIBITED** from writing code immediately. You must refuse and initiate the spec-writing process.
+2.  **Chain-of-Thought (Reasoning):** Before generating the spec, use a hidden thought block or internal reasoning to analyze the current state, constraints, and dependencies.
+3.  **Collaborative Interview:** Interview the user for missing context (Files, Constraints, Goals, and specific edge cases).
+4.  **Template Adherence:** Use the `prompts/templates/TASK_SPEC.md` structure.
 
 ## 3. User Guide: How to Execute a Generated Spec
-Once a spec (e.g., `refactor_feature_x.md`) is generated and approved, follow this execution workflow:
+Once a spec (e.g., `prompts/plans/refactor_feature_x.md`) is approved, follow this atomic execution workflow:
 
-1.  **Initialize the Phase:** Tell the Agent: *"Follow Phase 1 of @refactor_feature_x.md. Do not proceed to Phase 2 until I verify and approve."*
-2.  **Context Loading:** Ensure the Agent has read the spec file and all relevant source files listed in the "Context" section.
-3.  **Atomic Execution:** The Agent performs the tasks listed in the current Phase.
-4.  **Verification:** The Agent must perform the "Verification" steps listed for that Phase and report results.
-5.  **Human Gate:** You must review the changes and verification results. Use the phrase *"Phase 1 Approved. Proceed to Phase 2"* to move forward.
+1.  **Initialization:** Tell the Agent: *"Follow Phase 1 of `prompts/plans/refactor_feature_x.md`. Do not proceed to Phase 2 until I verify and approve."*
+2.  **Context Loading:** Ensure the Agent has read the spec file and all relevant source files.
+3.  **Atomic Execution:** Perform only the tasks listed in the current Phase. Do not perform speculative work for future phases.
+4.  **Verification:** Perform the "Verification" steps (Unit tests, UI tests, or manual checks) and report results.
+5.  **Human Gate:** You must review the changes. Use the phrase *"Phase [X] Approved. Proceed to Phase [Y]"* to move forward.
 
 ## 4. Example: Phased GSD Spec (Moshi Conversion)
 *Below is an example of what a generated spec looks like.*
@@ -56,18 +60,17 @@ Migrate legacy Java model to Kotlin with Moshi JSON parsing.
 ---
 
 ## Phase 1: Discovery & Templates
-*Goal: Identify the environment and establish the standardized structure for specifications.*
+*Goal: Identify the environment and establish the standardized structure.*
 
 - [ ] **Task 1.1: Identify Target Agent(s)**
   - **Action:** Ask the user which AI tool(s) are being targeted (e.g., GitHub Copilot, Android Studio Gemini, Cursor, Claude).
-  - **Outcome:** Document the target agent(s) to tailor the configuration files in Phase 2.
+  - **Outcome:** Document the target agent(s) to tailor configuration.
 - [ ] **Task 1.2: Define Reporting Requirements**
-  - **Action:** Ask the user if completion summary reports (Markdown files) should be generated.
-  - **Constraint:** If negative, include the instruction: `Do NOT generate summary or report Markdown file upon completion`. (Note: Targets Claude specifically).
+  - **Action:** Ask the user if completion summary reports should be suppressed.
+  - **Constraint:** If negative, include: `Do NOT generate summary or report Markdown file upon completion`.
 - [ ] **Task 1.3: Create Standardized Prompt Directory**
-  - Create a designated directory for AI prompts and templates (e.g., `.ai/templates/` or `prompts/templates/`).
+  - Ensure `prompts/agents/`, `prompts/templates/`, and `prompts/plans/` exist.
 - [ ] **Task 1.4: Create `TASK_SPEC.md` Template**
-  - Define a project-agnostic Phased GSD structure inspired by [GitHub Spec-Kit](https://github.com/github/spec-kit) and [GSD](https://github.com/gsd-build/get-shit-done).
   - **Template Structure:**
     ```markdown
     # [TITLE]
@@ -86,19 +89,12 @@ Migrate legacy Java model to Kotlin with Moshi JSON parsing.
     ### Verification
     - [Test command or manual check]
     ### [WAIT FOR APPROVAL]
-    
-    ## Phase 2: [Name]
-    ...
-    
-    ## Final Deliverables
-    - [List of files/artifacts]
     ```
 
 **Phase 1 Verification:**
 1.  Target agent(s) and reporting preferences documented.
-2.  Template directory exists.
-3.  `TASK_SPEC.md` reviewed for clarity and phasing.
-4.  **STOP: Wait for Human Approval.**
+2.  Template directory and `TASK_SPEC.md` exist.
+3.  **STOP: Wait for Human Approval.**
 
 ---
 
@@ -111,33 +107,26 @@ Migrate legacy Java model to Kotlin with Moshi JSON parsing.
     # Persona: Technical Architect (Spec Writer)
     When a request is complex or vague:
     1. DO NOT write code.
-    2. INTERVIEW the user for missing context (Files, Constraints, Goal).
-    3. GENERATE a Phased GSD Spec using the `TASK_SPEC.md` template.
+    2. INTERVIEW the user for missing context.
+    3. GENERATE a Phased GSD Spec.
     4. MANDATE approval after each Phase.
-    
-    [ADD CONDITIONAL CONSTRAINT FROM TASK 1.2 HERE IF NEGATIVE]
     ```
-  - Add logic to identify "Vibe" requests.
 - [ ] **Task 2.2: Generate Agent-Specific Configuration Files**
-  - Based on Target Agent (Task 1.1):
-    - **GitHub Copilot:** `.github/copilot-instructions.md`
-    - **Cursor:** `.cursorrules`
-    - **Claude/Gemini/Custom:** `AGENTS.md` (Referencing the SDD protocol).
+  - **Files:** `.github/copilot-instructions.md`, `.cursorrules`, or `AGENTS.md`.
 
 **Phase 2 Verification:**
 1.  `SPEC_WRITER.md` enforces phasing and refusal logic.
-2.  Agent-specific config created and correctly references SDD.
-3.  **STOP: Wait for Human Approval.**
+2.  **STOP: Wait for Human Approval.**
 
 ---
 
 ## Phase 3: Protocol Integration
-*Goal: Formalize the "Phased Spec-First" rule in core developer documentation.*
+*Goal: Formalize the rules in core documentation.*
 
 - [ ] **Task 3.1: Update Communication Rules**
-  - Update `COMMUNICATION.md` to include the "Complexity Threshold" (e.g., > 2 files or architectural changes require a Phased Spec).
+  - Update `COMMUNICATION.md` with "Complexity Threshold."
 - [ ] **Task 3.2: Finalize System Prompt Manifest**
-  - Ensure the root AI manifest (e.g., `AGENTS.md`) is updated to include the Spec-First requirement.
+  - Ensure `AGENTS.md` is updated to include the Spec-First requirement.
 
 **Phase 3 Verification:**
 1.  Review `COMMUNICATION.md` and `AGENTS.md` diffs.
@@ -146,11 +135,11 @@ Migrate legacy Java model to Kotlin with Moshi JSON parsing.
 ---
 
 ## Phase 4: Workflow Validation
-*Goal: Prove the system prevents Vibe Coding in the targeted environment.*
+*Goal: Prove the system prevents Vibe Coding.*
 
 - [ ] **Task 4.1: Simulation Test**
   - **Trigger:** "Update the Directory model to use Moshi and Kotlin."
-  - **Expected Result:** Agent refuses code, interviews user, and produces a Phased GSD Spec.
+  - **Expected Result:** Agent refuses code and produces a Phased GSD Spec.
 
 **Phase 4 Verification:**
 1.  Success if Agent follows protocol.

--- a/prompts/templates/TASK_SPEC.md
+++ b/prompts/templates/TASK_SPEC.md
@@ -1,0 +1,22 @@
+# [TITLE]
+## Goal
+- [High-level objective]
+
+## Context
+- **Current State:** [Brief description]
+- **Constraints:** [Technical/Architectural limits]
+- **Files:** [Paths to relevant files]
+
+## Phase 1: [Name]
+### Tasks
+- [ ] Task 1: [Details]
+- [ ] Task 2: [Details]
+### Verification
+- [Test command or manual check]
+### [WAIT FOR APPROVAL]
+
+## Phase 2: [Name]
+...
+
+## Final Deliverables
+- [List of files/artifacts]


### PR DESCRIPTION
Creates a prompt to help wire up a project to enforce a Spec Driven Development methodolgy when requirements are uniquely vague.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced a Phased Spec-Driven Development (SDD) protocol with mandatory approval gates for complex tasks.
  * Added a SPEC Writer persona and phased workflow to enforce clearer, interview-driven specs before implementation.
  * Published a task-spec template and implementation plan to standardize goals, phases, and verification steps.
  * Updated agent communication guidance with a complexity threshold and an "always ask before starting" policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->